### PR TITLE
fix #76 and #80: Use Name instead of Description for rclone type param

### DIFF
--- a/src/components/RemoteCreateDrawer.tsx
+++ b/src/components/RemoteCreateDrawer.tsx
@@ -182,10 +182,10 @@ export default function RemoteCreateDrawer({
         e.preventDefault()
         setIsSaving(true)
 
-        const formData = new FormData(e.currentTarget)
-        const data: Record<string, string | boolean> = {}
+        // take data from config state, not form
+        const data = structuredClone(config)
 
-        for (const [key, value] of formData.entries()) {
+        for (const [key, value] of Object.entries(data)) {
             if (value.toString().trim() === '') continue
             if (
                 e.currentTarget[key] instanceof HTMLInputElement &&


### PR DESCRIPTION
Implements the fix suggested on #76. I also saw the error reported in #80 so it probably fixes that too because rclone hasnt create the remote but rclone-ui thinks it has.

Tested using Dropbox and the browser opens for authentication.