### PR TITLE
fixed chip click not being triggered due to tauri drag region

### DIFF
--- a/src/components/OptionsSection.tsx
+++ b/src/components/OptionsSection.tsx
@@ -271,6 +271,7 @@ export default function OptionsSection({
                                     content: '!cursor-pointer',
                                 }}
                                 size="sm"
+                                as={'button'}
                             >
                                 {option.Name}
                             </Chip>


### PR DESCRIPTION
The click from the Chip-Component inside the `OptionsSection` is not being triggered.
It seems that the tauri-drag-region is intercepting the click-handler and not passing it along to the child components.
Another approach would've been to use `onMouseUp` instead of `onClick` but I prefer the more generalized solution.