### PR TITLE
fix: Windows toolbar clipping

### DIFF
--- a/src-tauri/common/shortcut.rs
+++ b/src-tauri/common/shortcut.rs
@@ -1,9 +1,9 @@
 use tauri::{AppHandle, Manager, WebviewWindow, WebviewWindowBuilder};
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutState};
 
-use super::window::make_transparent;
 #[cfg(target_os = "linux")]
 use super::window::focus_window_linux;
+use super::window::make_transparent;
 
 pub const DEFAULT_TOOLBAR_SHORTCUT: &str = "CmdOrCtrl+Shift+/";
 const TOOLBAR_WINDOW_LABEL: &str = "Toolbar";
@@ -12,6 +12,16 @@ const TOOLBAR_WINDOW_LABEL: &str = "Toolbar";
 const TOOLBAR_WIDTH: f64 = 702.0;
 #[cfg(target_os = "windows")]
 const TOOLBAR_HEIGHT: f64 = 460.0;
+
+#[cfg(target_os = "windows")]
+fn refresh_toolbar_bounds(window: &WebviewWindow) -> Result<(), tauri::Error> {
+    // WebView2 can retain stale bounds when this initially-hidden window is shown.
+    // A real resize (for example maximizing the window) fixes the clipped viewport,
+    // so force the same bounds refresh without leaving the toolbar enlarged.
+    window.set_size(tauri::LogicalSize::new(TOOLBAR_WIDTH + 1.0, TOOLBAR_HEIGHT))?;
+    window.set_size(tauri::LogicalSize::new(TOOLBAR_WIDTH, TOOLBAR_HEIGHT))?;
+    Ok(())
+}
 
 fn create_toolbar_window(app_handle: &AppHandle) -> Result<WebviewWindow, tauri::Error> {
     let monitor = match app_handle.primary_monitor()? {
@@ -119,6 +129,8 @@ pub fn show_toolbar_window(app_handle: &AppHandle) -> Result<(), tauri::Error> {
     if let Some(window) = app_handle.get_webview_window(TOOLBAR_WINDOW_LABEL) {
         window.show()?;
         window.unminimize()?;
+        #[cfg(target_os = "windows")]
+        refresh_toolbar_bounds(&window)?;
         window.set_focus()?;
         #[cfg(target_os = "linux")]
         focus_window_linux(app_handle, &window);
@@ -136,6 +148,8 @@ fn open_toolbar(app_handle: &AppHandle) -> Result<(), tauri::Error> {
         } else {
             window.show()?;
             window.unminimize()?;
+            #[cfg(target_os = "windows")]
+            refresh_toolbar_bounds(&window)?;
             window.set_focus()?;
             #[cfg(target_os = "linux")]
             focus_window_linux(app_handle, &window);

--- a/src/pages/Toolbar.tsx
+++ b/src/pages/Toolbar.tsx
@@ -499,10 +499,15 @@ export default function Toolbar() {
     }, [highlightedIndex, engineResults])
 
     return (
-        <div className="flex flex-col items-center justify-center w-full h-screen pb-[15vh]">
+        <div
+            className={cn(
+                'flex flex-col items-center justify-center w-full h-screen overflow-hidden',
+                !isWindows && 'pb-[15vh]'
+            )}
+        >
             <div
                 ref={activeAreaRef}
-                className="flex border-divider border flex-col items-center justify-center bg-content2/[0.97] w-[700px] rounded-large"
+                className="flex border-divider border flex-col items-center justify-center bg-content2/[0.97] w-full max-w-[700px] max-h-full rounded-large"
             >
                 <div
                     data-tauri-drag-region={true}
@@ -532,7 +537,10 @@ export default function Toolbar() {
 
                 <Divider />
 
-                <ScrollShadow className="h-[400px] w-full p-2" onMouseMove={handleMouseMove}>
+                <ScrollShadow
+                    className="h-[400px] min-h-0 w-full p-2"
+                    onMouseMove={handleMouseMove}
+                >
                     {engineResults.map((result, index) => {
                         const isActive = index === highlightedIndex
                         const elementId = `tb-result-${result.id.replace(ELEMENT_ID_REGEX, '-')}`


### PR DESCRIPTION
This PR is done by Codex with attempt to solve #194 .

The toolbar now works for me on Windows 10:
<img width="870" height="570" alt="image" src="https://github.com/user-attachments/assets/24c47ce8-1b48-4927-b440-6368472ec849" />
