### PR TITLE
Add manual Copy + Verify workflow

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,8 @@
 {
     "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
     "organizeImports": {
-        "enabled": true
+        "enabled": true,
+        "ignore": ["node_modules/*", "dist/*", ".work/*", "*.js", "*.mjs"]
     },
     "linter": {
         "enabled": true,
@@ -41,7 +42,7 @@
                 "all": false
             }
         },
-        "ignore": ["node_modules/*", "dist/*", ".work/*", "*.js"]
+        "ignore": ["node_modules/*", "dist/*", ".work/*", "*.js", "*.mjs"]
     },
     "formatter": {
         "enabled": true,
@@ -49,7 +50,7 @@
         "indentStyle": "space",
         "indentWidth": 4,
         "lineWidth": 100,
-        "ignore": ["node_modules/*", "dist/*", ".work/*"]
+        "ignore": ["node_modules/*", "dist/*", ".work/*", "*.js", "*.mjs"]
     },
     "javascript": {
         "formatter": {

--- a/docs/copy-verify-plan.md
+++ b/docs/copy-verify-plan.md
@@ -1,0 +1,58 @@
+# Rclone UI Fork — Copy + Verify Engineering Plan
+
+## Scope
+
+Add a manual-only `Copy + Verify` workflow to the existing Tauri 2 React/TypeScript application. Existing `Copy` remains behaviorally compatible, including its scheduler and dry-run paths. The feature uses rclone RC APIs only: it does not vendor rclone, add a database, or implement a custom comparison engine.
+
+## Architecture
+
+- Extract a pure transfer planner shared by Copy and Copy + Verify. It preserves destination mapping, source de-duplication, filters, remote options, and local/remote support.
+- Represent each effective source as a transfer unit containing copy and verification batch inputs. Directories verify the exact destination directory; files verify their parent directories with a literal, root-anchored filename include rule.
+- Verify with asynchronous `operations/check` calls using `oneWay=true`, `missingOnDst=true`, `differ=true`, `error=true`, and `match=false`. Verification never inherits size-only, ignore-checksum, or dry-run weakening.
+- Enforce strict Copy + Verify completion: the parent job is finished, the daemon `executeId` matches, the result count matches submitted inputs, and every child is error-free before verification starts.
+- Persist active operations and 90-day terminal history in the existing per-host store, with immutable operation IDs, stable job groups, narrow updates, and a schema-versioned migration.
+- Make the hidden main window the single writer and coordinator. UI windows submit typed start, stop, repair, and verify-again commands with request IDs and acknowledgements.
+- Reconcile unfinished operations on restart using both job ID and daemon execute ID. Ambiguous, expired, incomplete, or daemon-restarted work becomes `VERIFICATION REQUIRED`; success is never inferred from absence or partial output.
+- Suppress internal jobs from generic Transfers and show one combined operation card/details drawer with stage labels, report, repair, verify-again, and stop actions when valid.
+
+## Persisted model
+
+```ts
+type CopyVerifyPhase =
+  | 'submitting_copy' | 'copying' | 'submitting_verification'
+  | 'verifying' | 'repairing' | 'verification_required' | 'complete'
+
+type CopyVerifyResult =
+  | 'verified' | 'verified_with_limitations' | 'copy_failed'
+  | 'verification_failed' | 'cancelled' | null
+```
+
+Each operation stores its host, sources, destination, timestamps, phase/result, verification method, checked-file count, contextual missing/different/error lists, durations, job references (`jobId` plus `executeId`), transfer units, and execution options. Successful filenames and remote-option values are not persisted in reports/history.
+
+Verification method classification is checksum when every unit reports a real hash, size-only when all report `none`, mixed when both occur, and unknown when the method is absent/unrecognized. The UI says “rclone-reported” and uses `VERIFIED WITH LIMITATIONS` for every non-full-checksum case.
+
+## UI
+
+- Add `/copy-verify` and toolbar/command-menu entry `Copy + Verify`.
+- Parameterize Copy with a default `copy` mode and a manual-only `copy-verify` mode. The default route retains existing Cron, Dry Run, labels, help, and launch behavior.
+- Show exactly `This operation may replace differing destination files.` before local-to-remote starts; do not show it for remote-to-local or remote-to-remote.
+- Display combined `COPYING`, `VERIFYING`, `VERIFIED`, `VERIFIED WITH LIMITATIONS`, `VERIFICATION FAILED`, `COPY FAILED`, `REPAIRING`, and `VERIFICATION REQUIRED` states.
+- Repair only missing/different files, force targeted overwrite, never delete extra destination files, and always run a complete verification again after successful repair. Read/hash errors alone never enable repair.
+- Copy Report contains operation ID, timestamps, source/destination, result, method, counts, durations, job references, and complete issue sections while excluding successful filenames and options.
+
+## Delivery phases
+
+1. Fork/bootstrap, upstream remotes, this plan, Vitest, and test scripts.
+2. Pure planner extraction and unit tests.
+3. Typed rclone adapter and strict aggregation, verified against a temporary local `rclone rcd`.
+4. Host-store migration, coordinator, stable groups, notifications, and recovery boundaries.
+5. Copy + Verify route, command entries, mode parameterization, confirmation, collision errors, and acknowledgements.
+6. Combined Transfers/history cards, details drawer, report, retention, and Verify Again.
+7. Manual repair and complete recheck.
+8. Restart/daemon/expiry/host-switch hardening, accessibility, redacted logging, build checks, rebase, and push.
+
+## Acceptance
+
+Run `npm ci`, `npm run test`, `npm run build`, `cargo test --manifest-path src-tauri/Cargo.toml`, and `npx biome check .`. Cover planner edge cases, collision detection, verification flags/filter preservation, strict failure handling, hash classifications, issue aggregation, repair mapping, idempotent transitions, migration/retention, report escaping, exact confirmation text, unchanged Copy behavior, and local-rclone copy/check/repair/recovery scenarios.
+
+The feature branch is `feature/copy-verify`, based on upstream `main`. Rebase at phase boundaries and push green phases independently.

--- a/lib/copyVerify/commands.ts
+++ b/lib/copyVerify/commands.ts
@@ -1,0 +1,74 @@
+import { getCurrentWindow } from '@tauri-apps/api/window'
+import {
+    COPY_VERIFY_ACK,
+    COPY_VERIFY_COMMAND,
+    type CopyVerifyAck,
+    type CopyVerifyCommand,
+    emitToMain,
+} from '../events'
+import type { CopyArgs } from '../rclone/requests'
+
+type CopyVerifyRequest =
+    | { type: 'start'; args: CopyArgs }
+    | { type: 'repair'; operationId: string }
+    | { type: 'verify-again'; operationId: string }
+    | { type: 'stop'; operationId: string }
+
+async function request(command: CopyVerifyRequest): Promise<CopyVerifyAck> {
+    const requestId = crypto.randomUUID()
+    const fullCommand = { ...command, requestId } as CopyVerifyCommand
+    const window = getCurrentWindow()
+
+    return new Promise<CopyVerifyAck>((resolve, reject) => {
+        let unlisten: (() => void) | undefined
+        let settled = false
+        const timeout = setTimeout(() => {
+            if (settled) return
+            settled = true
+            unlisten?.()
+            reject(new Error('Timed out waiting for the Copy + Verify coordinator'))
+        }, 15_000)
+
+        window
+            .listen<CopyVerifyAck>(COPY_VERIFY_ACK, (event) => {
+                if (event.payload.requestId !== requestId || settled) return
+                settled = true
+                clearTimeout(timeout)
+                unlisten?.()
+                resolve(event.payload)
+            })
+            .then((dispose) => {
+                unlisten = dispose
+                return emitToMain(COPY_VERIFY_COMMAND, fullCommand)
+            })
+            .catch((error) => {
+                if (settled) return
+                settled = true
+                clearTimeout(timeout)
+                unlisten?.()
+                reject(error)
+            })
+    })
+}
+
+async function requireSuccess(command: CopyVerifyRequest): Promise<string | void> {
+    const ack = await request(command)
+    if (!ack.ok) throw new Error(ack.error || 'Copy + Verify command failed')
+    return ack.operationId
+}
+
+export function startCopyVerify(args: CopyArgs): Promise<string> {
+    return requireSuccess({ type: 'start', args }) as Promise<string>
+}
+
+export async function repairCopyVerify(operationId: string): Promise<void> {
+    await requireSuccess({ type: 'repair', operationId })
+}
+
+export async function verifyAgainCopyVerify(operationId: string): Promise<void> {
+    await requireSuccess({ type: 'verify-again', operationId })
+}
+
+export async function stopCopyVerify(operationId: string): Promise<void> {
+    await requireSuccess({ type: 'stop', operationId })
+}

--- a/lib/copyVerify/coordinator.ts
+++ b/lib/copyVerify/coordinator.ts
@@ -1,0 +1,558 @@
+import { getCurrentWindow } from '@tauri-apps/api/window'
+import { flushHostStore, useHostStore } from '../../store/host'
+import { selectCurrentHost, usePersistedStore } from '../../store/persisted'
+import type {
+    CopyVerifyOperation,
+    CopyVerifyUpdate,
+    RcloneJobRef,
+    TransferUnit,
+} from '../../types/copyVerify'
+import {
+    COPY_VERIFY_ACK,
+    COPY_VERIFY_COMMAND,
+    COPY_VERIFY_UPDATED,
+    type CopyVerifyCommand,
+} from '../events'
+import type { CopyArgs } from '../rclone/requests'
+import { buildCopyVerifyPlan } from './planner'
+import {
+    type SubmittedCopyVerifyJob,
+    getGroupStats,
+    getJobList,
+    stopCopyVerifyGroup,
+    submitCopyVerifyBatch,
+    waitForCopyVerifyJob,
+} from './rclone'
+import { buildRepairInputs } from './repair'
+import { buildCopyReport } from './report'
+import { aggregateCopyResult, aggregateVerificationResult, recoverFilesChecked } from './results'
+
+const COPY_VERIFY_GROUP_PREFIX = 'copy-verify'
+
+function nowIso(): string {
+    return new Date().toISOString()
+}
+
+function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error)
+}
+
+function durationSince(startedAt: string): number | undefined {
+    const started = Date.parse(startedAt)
+    if (!Number.isFinite(started)) return undefined
+    return Math.max(0, (Date.now() - started) / 1000)
+}
+
+function makeJobRef(
+    submitted: SubmittedCopyVerifyJob,
+    group: string,
+    attempt: number
+): RcloneJobRef {
+    return {
+        jobId: submitted.jobId,
+        executeId: submitted.executeId,
+        group,
+        attempt,
+        startedAt: nowIso(),
+    }
+}
+
+function appendIssues<T>(current: T[], additions: T[]): T[] {
+    return [...current, ...additions]
+}
+
+export class CopyVerifyCoordinator {
+    private readonly controllers = new Map<string, AbortController>()
+    private unlisten: (() => void) | undefined
+
+    async start(): Promise<void> {
+        const window = getCurrentWindow()
+        this.unlisten = await window.listen<CopyVerifyCommand>(COPY_VERIFY_COMMAND, (event) => {
+            this.handleCommand(event.payload).catch((error) =>
+                console.error('[CopyVerify] command failed', error)
+            )
+        })
+
+        const hostStore = useHostStore.getState()
+        hostStore.pruneCopyVerifyOperations()
+        await flushHostStore()
+        await this.reconcile()
+    }
+
+    dispose(): void {
+        this.unlisten?.()
+        this.unlisten = undefined
+        for (const controller of this.controllers.values()) controller.abort()
+        this.controllers.clear()
+    }
+
+    private async emitAck(payload: {
+        requestId: string
+        ok: boolean
+        operationId?: string
+        error?: string
+    }): Promise<void> {
+        await getCurrentWindow().emit(COPY_VERIFY_ACK, payload)
+    }
+
+    private async publish(operation: CopyVerifyOperation): Promise<void> {
+        await getCurrentWindow().emit(COPY_VERIFY_UPDATED, operation)
+    }
+
+    private async update(id: string, patch: CopyVerifyUpdate): Promise<CopyVerifyOperation> {
+        const hostStore = useHostStore.getState()
+        hostStore.updateCopyVerifyOperation(id, patch)
+        await flushHostStore()
+        const operation = useHostStore
+            .getState()
+            .copyVerifyOperations.find((item) => item.id === id)
+        if (!operation) throw new Error(`Copy + Verify operation ${id} no longer exists`)
+        await this.publish(operation)
+        return operation
+    }
+
+    private getOperation(id: string): CopyVerifyOperation {
+        const operation = useHostStore
+            .getState()
+            .copyVerifyOperations.find((item) => item.id === id)
+        if (!operation) throw new Error(`Copy + Verify operation ${id} was not found`)
+        return operation
+    }
+
+    private currentHostId(): string {
+        const hostId = usePersistedStore.getState().currentHostId
+        if (!hostId) throw new Error('No rclone host is selected')
+        if (!selectCurrentHost(usePersistedStore.getState())) {
+            throw new Error('The selected rclone host is unavailable')
+        }
+        return hostId
+    }
+
+    private controllerFor(id: string): AbortController {
+        const existing = this.controllers.get(id)
+        if (existing) return existing
+        const controller = new AbortController()
+        this.controllers.set(id, controller)
+        return controller
+    }
+
+    private async handleCommand(command: CopyVerifyCommand): Promise<void> {
+        try {
+            if (command.type === 'start') {
+                const operationId = await this.startCopy(command.args)
+                await this.emitAck({ requestId: command.requestId, ok: true, operationId })
+                return
+            }
+            if (command.type === 'repair') {
+                await this.startRepair(command.operationId)
+                await this.emitAck({ requestId: command.requestId, ok: true })
+                return
+            }
+            if (command.type === 'verify-again') {
+                await this.startVerification(command.operationId)
+                await this.emitAck({ requestId: command.requestId, ok: true })
+                return
+            }
+            await this.stop(command.operationId)
+            await this.emitAck({ requestId: command.requestId, ok: true })
+        } catch (error) {
+            await this.emitAck({
+                requestId: command.requestId,
+                ok: false,
+                error: errorMessage(error),
+            })
+        }
+    }
+
+    private async startCopy(args: CopyArgs): Promise<string> {
+        const hostId = this.currentHostId()
+        const plan = buildCopyVerifyPlan(args)
+        if (plan.units.length === 0) throw new Error('Select at least one source path')
+
+        const operationId = crypto.randomUUID()
+        const createdAt = nowIso()
+        const operation: CopyVerifyOperation = {
+            id: operationId,
+            hostId,
+            sources: [...args.sources],
+            destination: args.destination,
+            createdAt,
+            updatedAt: createdAt,
+            phase: 'submitting_copy',
+            result: null,
+            filesChecked: null,
+            missingFiles: [],
+            differentFiles: [],
+            errors: [],
+            verificationJobs: [],
+            repairJobs: [],
+            transferUnits: plan.units,
+            executionOptions: args.options,
+        }
+        useHostStore.getState().addCopyVerifyOperation(operation)
+        await flushHostStore()
+        await this.publish(operation)
+
+        const controller = this.controllerFor(operationId)
+        try {
+            const group = `${COPY_VERIFY_GROUP_PREFIX}/${operationId}/copy`
+            const submitted = await submitCopyVerifyBatch(plan.copyInputs, group)
+            const copyJob = makeJobRef(submitted, group, 1)
+            await this.update(operationId, { phase: 'copying', copyJob })
+            this.processCopy(operationId, submitted, controller).catch((error) =>
+                console.error('[CopyVerify] copy processing failed', error)
+            )
+            return operationId
+        } catch (error) {
+            await this.update(operationId, {
+                phase: 'complete',
+                result: 'copy_failed',
+                completedAt: nowIso(),
+                totalDurationSeconds: durationSince(createdAt),
+                errors: [{ unitId: 'operation', path: 'copy', message: errorMessage(error) }],
+            })
+            this.controllers.delete(operationId)
+            throw error
+        }
+    }
+
+    private async processCopy(
+        operationId: string,
+        submitted: SubmittedCopyVerifyJob,
+        controller: AbortController
+    ): Promise<void> {
+        try {
+            const operation = this.getOperation(operationId)
+            const status = await waitForCopyVerifyJob(submitted, { signal: controller.signal })
+            const aggregate = aggregateCopyResult(
+                status,
+                operation.transferUnits.length,
+                operation.transferUnits
+            )
+            const copyDurationSeconds = status.duration ?? durationSince(operation.createdAt)
+            if (!aggregate.success) {
+                await this.update(operationId, {
+                    phase: 'complete',
+                    result: 'copy_failed',
+                    completedAt: nowIso(),
+                    copyDurationSeconds,
+                    totalDurationSeconds: durationSince(operation.createdAt),
+                    errors: appendIssues(operation.errors, aggregate.errors),
+                })
+                this.controllers.delete(operationId)
+                return
+            }
+            await this.update(operationId, { copyDurationSeconds })
+            await this.startVerification(operationId, controller)
+        } catch (error) {
+            const current = this.getOperation(operationId)
+            if (current.phase === 'complete' || controller.signal.aborted) return
+            await this.markVerificationRequired(operationId, error)
+        }
+    }
+
+    private async startVerification(
+        operationId: string,
+        controller = this.controllerFor(operationId)
+    ): Promise<void> {
+        const operation = this.getOperation(operationId)
+        if (operation.hostId !== this.currentHostId()) {
+            throw new Error('Switch back to the operation host before verifying')
+        }
+        const attempt = operation.verificationJobs.length + 1
+        const group = `${COPY_VERIFY_GROUP_PREFIX}/${operationId}/verify/${attempt}`
+        await this.update(operationId, {
+            phase: 'submitting_verification',
+            result: null,
+            missingFiles: [],
+            differentFiles: [],
+            errors: [],
+        })
+
+        try {
+            const submitted = await submitCopyVerifyBatch(
+                operation.transferUnits.map((unit) => unit.verificationInput),
+                group
+            )
+            const verificationJob = makeJobRef(submitted, group, attempt)
+            await this.update(operationId, {
+                phase: 'verifying',
+                verificationJobs: [...operation.verificationJobs, verificationJob],
+            })
+            this.processVerification(operationId, submitted, verificationJob, controller).catch(
+                (error) => console.error('[CopyVerify] verification processing failed', error)
+            )
+        } catch (error) {
+            await this.markVerificationRequired(operationId, error)
+            throw error
+        }
+    }
+
+    private async processVerification(
+        operationId: string,
+        submitted: SubmittedCopyVerifyJob,
+        verificationJob: RcloneJobRef,
+        controller: AbortController
+    ): Promise<void> {
+        try {
+            const operation = this.getOperation(operationId)
+            const status = await waitForCopyVerifyJob(submitted, { signal: controller.signal })
+            let filesChecked: number | null = null
+            try {
+                filesChecked = recoverFilesChecked(await getGroupStats(verificationJob.group))
+            } catch (error) {
+                console.warn('[CopyVerify] files checked unavailable', errorMessage(error))
+            }
+            const aggregate = aggregateVerificationResult(status, operation.transferUnits)
+            const method = aggregate.method
+            const result = aggregate.success
+                ? method.kind === 'checksum'
+                    ? 'verified'
+                    : 'verified_with_limitations'
+                : 'verification_failed'
+            const completedAt = nowIso()
+            await this.update(operationId, {
+                phase: 'complete',
+                result,
+                completedAt,
+                verificationMethod: method,
+                filesChecked,
+                missingFiles: aggregate.missingFiles,
+                differentFiles: aggregate.differentFiles,
+                errors: aggregate.errors,
+                verificationDurationSeconds:
+                    status.duration ?? durationSince(verificationJob.startedAt),
+                totalDurationSeconds: durationSince(operation.createdAt),
+                verificationJobs: operation.verificationJobs.map((job) =>
+                    job.jobId === verificationJob.jobId ? { ...job, finishedAt: completedAt } : job
+                ),
+            })
+            this.controllers.delete(operationId)
+        } catch (error) {
+            const current = this.getOperation(operationId)
+            if (current.phase === 'complete' || controller.signal.aborted) return
+            await this.markVerificationRequired(operationId, error)
+        }
+    }
+
+    private async startRepair(operationId: string): Promise<void> {
+        const operation = this.getOperation(operationId)
+        if (operation.result !== 'verification_failed') {
+            throw new Error('Repair is only available after a verification failure')
+        }
+        if (operation.missingFiles.length === 0 && operation.differentFiles.length === 0) {
+            throw new Error('There are no missing or differing files to repair')
+        }
+        if (operation.hostId !== this.currentHostId()) {
+            throw new Error('Switch back to the operation host before repairing')
+        }
+
+        const repair = buildRepairInputs(operation)
+        const controller = this.controllerFor(operationId)
+        const attempt = operation.repairJobs.length + 1
+        const group = `${COPY_VERIFY_GROUP_PREFIX}/${operationId}/repair/${attempt}`
+        await this.update(operationId, { phase: 'repairing', result: null })
+
+        try {
+            const submitted = await submitCopyVerifyBatch(repair.inputs, group)
+            const repairJob = makeJobRef(submitted, group, attempt)
+            await this.update(operationId, {
+                phase: 'repairing',
+                repairJobs: [...operation.repairJobs, repairJob],
+            })
+            this.processRepair(operationId, submitted, repairJob, repair.units, controller).catch(
+                (error) => console.error('[CopyVerify] repair processing failed', error)
+            )
+        } catch (error) {
+            await this.markVerificationRequired(operationId, error)
+            throw error
+        }
+    }
+
+    private async processRepair(
+        operationId: string,
+        submitted: SubmittedCopyVerifyJob,
+        repairJob: RcloneJobRef,
+        units: TransferUnit[],
+        controller: AbortController
+    ): Promise<void> {
+        try {
+            const operation = this.getOperation(operationId)
+            const status = await waitForCopyVerifyJob(submitted, { signal: controller.signal })
+            const aggregate = aggregateCopyResult(status, units.length, units)
+            if (!aggregate.success) {
+                await this.update(operationId, {
+                    phase: 'complete',
+                    result: 'verification_failed',
+                    completedAt: nowIso(),
+                    errors: appendIssues(operation.errors, aggregate.errors),
+                    repairJobs: operation.repairJobs.map((job) =>
+                        job.jobId === repairJob.jobId ? { ...job, finishedAt: nowIso() } : job
+                    ),
+                })
+                this.controllers.delete(operationId)
+                return
+            }
+            await this.update(operationId, {
+                repairJobs: operation.repairJobs.map((job) =>
+                    job.jobId === repairJob.jobId ? { ...job, finishedAt: nowIso() } : job
+                ),
+            })
+            await this.startVerification(operationId, controller)
+        } catch (error) {
+            const current = this.getOperation(operationId)
+            if (current.phase === 'complete' || controller.signal.aborted) return
+            await this.markVerificationRequired(operationId, error)
+        }
+    }
+
+    private async markVerificationRequired(operationId: string, error: unknown): Promise<void> {
+        const operation = this.getOperation(operationId)
+        if (operation.phase === 'complete' || operation.phase === 'verification_required') return
+        await this.update(operationId, {
+            phase: 'verification_required',
+            result: null,
+            completedAt: undefined,
+            errors: appendIssues(operation.errors, [
+                { unitId: 'operation', path: 'recovery', message: errorMessage(error) },
+            ]),
+        })
+    }
+
+    private async stop(operationId: string): Promise<void> {
+        const operation = this.getOperation(operationId)
+        if (operation.phase === 'complete' || operation.phase === 'verification_required') {
+            throw new Error('This Copy + Verify operation is not running')
+        }
+        const controller = this.controllers.get(operationId)
+        controller?.abort()
+        const job =
+            operation.phase === 'copying'
+                ? operation.copyJob
+                : operation.phase === 'repairing'
+                  ? operation.repairJobs.at(-1)
+                  : operation.verificationJobs.at(-1)
+        if (job) await stopCopyVerifyGroup(job.group).catch(() => undefined)
+
+        if (operation.phase === 'copying' || operation.phase === 'submitting_copy') {
+            await this.update(operationId, {
+                phase: 'complete',
+                result: 'cancelled',
+                completedAt: nowIso(),
+                totalDurationSeconds: durationSince(operation.createdAt),
+            })
+        } else {
+            await this.update(operationId, {
+                phase: 'verification_required',
+                result: null,
+                errors: appendIssues(operation.errors, [
+                    {
+                        unitId: 'operation',
+                        path: 'stop',
+                        message: 'Stopped before verification completed',
+                    },
+                ]),
+            })
+        }
+        this.controllers.delete(operationId)
+    }
+
+    private async reconcile(): Promise<void> {
+        const hostId = usePersistedStore.getState().currentHostId
+        if (!hostId) return
+        const operations = useHostStore
+            .getState()
+            .copyVerifyOperations.filter(
+                (operation) =>
+                    operation.hostId === hostId &&
+                    !['complete', 'verification_required'].includes(operation.phase)
+            )
+        if (operations.length === 0) return
+
+        const jobs = await getJobList().catch(() => null)
+        if (!jobs) {
+            for (const operation of operations) {
+                await this.markVerificationRequired(
+                    operation.id,
+                    'Unable to reconcile rclone jobs after restart'
+                )
+            }
+            return
+        }
+
+        for (const operation of operations) {
+            const job =
+                operation.phase === 'copying'
+                    ? operation.copyJob
+                    : operation.phase === 'repairing'
+                      ? operation.repairJobs.at(-1)
+                      : operation.verificationJobs.at(-1)
+            if (!job || job.executeId !== jobs.executeId || !jobs.jobids.includes(job.jobId)) {
+                await this.markVerificationRequired(
+                    operation.id,
+                    'The submitted rclone job could not be reattached'
+                )
+                continue
+            }
+            const controller = this.controllerFor(operation.id)
+            const submitted = { jobId: job.jobId, executeId: job.executeId }
+            if (operation.phase === 'copying' && operation.copyJob) {
+                this.processCopy(operation.id, submitted, controller).catch((error) =>
+                    console.error('[CopyVerify] recovery copy failed', error)
+                )
+            } else if (operation.phase === 'repairing' && operation.repairJobs.at(-1)) {
+                const repair = buildRepairInputs(operation)
+                this.processRepair(
+                    operation.id,
+                    submitted,
+                    operation.repairJobs.at(-1)!,
+                    repair.units,
+                    controller
+                ).catch((error) => console.error('[CopyVerify] recovery repair failed', error))
+            } else if (operation.phase === 'verifying' && operation.verificationJobs.at(-1)) {
+                this.processVerification(
+                    operation.id,
+                    submitted,
+                    operation.verificationJobs.at(-1)!,
+                    controller
+                ).catch((error) =>
+                    console.error('[CopyVerify] recovery verification failed', error)
+                )
+            } else {
+                await this.markVerificationRequired(
+                    operation.id,
+                    'Operation was interrupted before a job reference was saved'
+                )
+            }
+        }
+    }
+
+    copyReport(operationId: string): string {
+        return buildCopyReport(this.getOperation(operationId))
+    }
+
+    async markDaemonRestarted(): Promise<void> {
+        await this.markActiveOperationsRequired('The rclone daemon was restarted')
+    }
+
+    async markHostChanged(): Promise<void> {
+        await this.markActiveOperationsRequired('The rclone host changed')
+    }
+
+    private async markActiveOperationsRequired(message: string): Promise<void> {
+        const active = useHostStore
+            .getState()
+            .copyVerifyOperations.filter(
+                (operation) => !['complete', 'verification_required'].includes(operation.phase)
+            )
+        for (const operation of active) {
+            await this.markVerificationRequired(operation.id, message)
+        }
+    }
+}
+
+export async function initCopyVerifyCoordinator(): Promise<CopyVerifyCoordinator> {
+    const coordinator = new CopyVerifyCoordinator()
+    await coordinator.start()
+    return coordinator
+}

--- a/lib/copyVerify/history.test.ts
+++ b/lib/copyVerify/history.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import type { CopyVerifyOperation } from '../../types/copyVerify'
+import { COPY_VERIFY_RETENTION_MS, pruneTerminalOperations } from './history'
+
+function operation(
+    id: string,
+    phase: CopyVerifyOperation['phase'],
+    completedAt: string
+): CopyVerifyOperation {
+    return {
+        id,
+        hostId: 'local',
+        sources: ['/source/'],
+        destination: '/destination/',
+        createdAt: completedAt,
+        updatedAt: completedAt,
+        completedAt,
+        phase,
+        result: phase === 'complete' ? 'verified' : null,
+        filesChecked: null,
+        missingFiles: [],
+        differentFiles: [],
+        errors: [],
+        verificationJobs: [],
+        repairJobs: [],
+        transferUnits: [],
+        executionOptions: { copy: {}, config: {}, filter: {}, remotes: {} },
+    }
+}
+
+describe('Copy + Verify history retention', () => {
+    it('keeps the exact 90-day boundary and unfinished work', () => {
+        const now = Date.parse('2026-08-17T00:00:00.000Z')
+        const boundary = new Date(now - COPY_VERIFY_RETENTION_MS).toISOString()
+        const retained = operation(
+            'retained',
+            'complete',
+            new Date(now - COPY_VERIFY_RETENTION_MS + 1).toISOString()
+        )
+        const expired = operation('expired', 'complete', boundary)
+        const active = operation('active', 'verifying', boundary)
+        const required = operation('required', 'verification_required', boundary)
+
+        expect(
+            pruneTerminalOperations([retained, expired, active, required], now).map(
+                (item) => item.id
+            )
+        ).toEqual(['retained', 'active'])
+    })
+})

--- a/lib/copyVerify/history.ts
+++ b/lib/copyVerify/history.ts
@@ -1,0 +1,14 @@
+import type { CopyVerifyOperation } from '../../types/copyVerify'
+
+export const COPY_VERIFY_RETENTION_MS = 90 * 24 * 60 * 60 * 1000
+
+export function pruneTerminalOperations(
+    operations: CopyVerifyOperation[],
+    now: number
+): CopyVerifyOperation[] {
+    return operations.filter((operation) => {
+        if (!['complete', 'verification_required'].includes(operation.phase)) return true
+        const completedAt = Date.parse(operation.completedAt ?? operation.updatedAt)
+        return !Number.isFinite(completedAt) || now - completedAt < COPY_VERIFY_RETENTION_MS
+    })
+}

--- a/lib/copyVerify/planner.test.ts
+++ b/lib/copyVerify/planner.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import { type CopyArgs, buildCopyInputs, buildCopyRequests } from '../rclone/requests'
+import { buildCopyVerifyPlan } from './planner'
+
+function copyArgs(overrides: Partial<CopyArgs> = {}): CopyArgs {
+    return {
+        sources: ['/source/'],
+        destination: '/destination/',
+        options: { copy: {}, config: {}, filter: {}, remotes: {} },
+        ...overrides,
+    }
+}
+
+describe('buildCopyVerifyPlan', () => {
+    it('shares the existing Copy fan-out byte-for-byte', () => {
+        const args = copyArgs({ sources: ['/source/', '/source/nested.txt'] })
+        const plan = buildCopyVerifyPlan(args)
+        const copyRequest = buildCopyRequests(args)[0]
+
+        expect(plan.copyInputs).toEqual(buildCopyInputs(args))
+        expect(plan.copyInputs).toEqual(copyRequest.body.inputs)
+        expect(plan.units).toHaveLength(1)
+    })
+
+    it('creates an exact, escaped file verification filter', () => {
+        const plan = buildCopyVerifyPlan(
+            copyArgs({
+                sources: ['/source/price[1]*?.txt'],
+                destination: '/destination/',
+            })
+        )
+
+        expect(plan.units[0].kind).toBe('file')
+        expect(plan.units[0].verificationInput).toMatchObject({
+            _path: 'operations/check',
+            oneWay: true,
+            missingOnDst: true,
+            differ: true,
+            error: true,
+            match: false,
+        })
+        expect(JSON.parse(plan.units[0].verificationInput._filter)).toEqual({
+            IncludeRule: ['/price\\[1\\]\\*\\?.txt'],
+        })
+    })
+
+    it('preserves folder filters and forces weak verification options off', () => {
+        const plan = buildCopyVerifyPlan(
+            copyArgs({
+                options: {
+                    copy: { size_only: true, ignore_checksum: true },
+                    config: { transfers: 4 },
+                    filter: { exclude: ['*.tmp'] },
+                    remotes: {},
+                },
+            })
+        )
+
+        const verification = plan.units[0].verificationInput
+        expect(verification._filter).toContain('ExcludeRule')
+        expect(verification._config).toContain('"SizeOnly":false')
+        expect(verification._config).toContain('"IgnoreChecksum":false')
+    })
+
+    it('blocks two effective sources that target the same destination object', () => {
+        expect(() =>
+            buildCopyVerifyPlan(
+                copyArgs({
+                    sources: ['/first/report.txt', '/second/report.txt'],
+                })
+            )
+        ).toThrow('destination collision')
+    })
+
+    it('treats local Windows destination paths as case-insensitive', () => {
+        expect(() =>
+            buildCopyVerifyPlan(
+                copyArgs({
+                    sources: ['C:/first/report.txt', 'C:/second/report.txt'],
+                    destination: 'C:/Destination/',
+                })
+            )
+        ).toThrow('destination collision')
+    })
+
+    it('does not treat remote-to-local or local-to-local planning as a collision by direction', () => {
+        const plan = buildCopyVerifyPlan(
+            copyArgs({
+                sources: ['remote:folder/'],
+                destination: '/destination/',
+            })
+        )
+        expect(plan.units[0].destinationDisplayPath).toBe(':local:destination/folder')
+    })
+})

--- a/lib/copyVerify/planner.ts
+++ b/lib/copyVerify/planner.ts
@@ -1,0 +1,164 @@
+import type { CopyVerifyPlan, TransferUnit } from '../../types/copyVerify'
+import { getFsInfo } from '../format'
+import {
+    type BatchInput,
+    type CopyArgs,
+    buildCopyInputs,
+    serializeOptions,
+    toConfigParam,
+    toFilterParam,
+} from '../rclone/requests'
+
+const RE_TRAILING_SLASHES = /\/+$/
+const RE_LOCAL_WINDOWS_PATH = /^:local:[A-Za-z]:\//
+
+function sourceIsFolder(source: string): boolean {
+    return source.endsWith('/') || source.endsWith('\\')
+}
+
+function normalizePathForComparison(path: string): string {
+    const normalized = path.replace(/\\/g, '/')
+    if (normalized.length <= 1) return normalized
+    const withoutTrailingSlash = normalized.replace(RE_TRAILING_SLASHES, '')
+    return RE_LOCAL_WINDOWS_PATH.test(withoutTrailingSlash)
+        ? withoutTrailingSlash.toLowerCase()
+        : withoutTrailingSlash
+}
+
+function escapeFilterLiteral(value: string): string {
+    // rclone filter rules use glob metacharacters. Escaping each one keeps a filename such as
+    // `report[1]*?.txt` literal while the leading slash anchors it at the selected parent root.
+    return value.replace(/[\\*?\[\]]/g, (character) => `\\${character}`)
+}
+
+function parentFs(root: string, filePath: string): string {
+    const separator = filePath.lastIndexOf('/')
+    if (separator < 0) return root
+    return `${root}${filePath.slice(0, separator + 1)}`
+}
+
+function destinationObjectPath(destination: string, sourceName: string): string {
+    const destinationInfo = getFsInfo(destination)
+    return `${destinationInfo.fullDirPath}${sourceName}`
+}
+
+function destinationRemoteOptions(args: CopyArgs, path: string) {
+    const remoteName = getFsInfo(path).remoteName
+    return args.options.remotes?.[remoteName]
+}
+
+function verificationConfig(args: CopyArgs): string | undefined {
+    return toConfigParam({
+        ...(args.options.copy || {}),
+        ...(args.options.config || {}),
+        // Verification is always a real content comparison when the backend exposes a hash.
+        size_only: false,
+        ignore_checksum: false,
+        dry_run: false,
+    })
+}
+
+function buildVerificationInput(
+    args: CopyArgs,
+    source: string,
+    copyInput: BatchInput,
+    configParam: string | undefined
+): BatchInput {
+    const sourceInfo = getFsInfo(source)
+    const destinationInfo = getFsInfo(args.destination)
+    const sourceOptions = destinationRemoteOptions(args, source)
+    const destinationOptions = destinationRemoteOptions(args, args.destination)
+
+    const common = {
+        oneWay: true,
+        missingOnDst: true,
+        differ: true,
+        error: true,
+        match: false,
+        ...(configParam ? { _config: configParam } : {}),
+    }
+
+    if (sourceInfo.type === 'folder') {
+        return {
+            _path: 'operations/check',
+            srcFs: copyInput.srcFs,
+            dstFs: copyInput.dstFs,
+            ...common,
+            ...(copyInput._filter ? { _filter: copyInput._filter } : {}),
+        }
+    }
+
+    const sourceParent = parentFs(sourceInfo.root, sourceInfo.filePath)
+    const destinationParent = `${destinationInfo.root}${destinationInfo.dirPath}`
+    const filenameRule = `/${escapeFilterLiteral(sourceInfo.name)}`
+
+    return {
+        _path: 'operations/check',
+        srcFs: serializeOptions(sourceParent, { remote: sourceOptions }),
+        dstFs: serializeOptions(destinationParent, { remote: destinationOptions }),
+        ...common,
+        // File copy inputs are intentionally not filterable in the legacy request builder. The
+        // verification request is rooted at each parent and uses one exact filename rule instead.
+        _filter: toFilterParam({ include: [filenameRule] }),
+    }
+}
+
+function effectiveSources(args: CopyArgs): string[] {
+    const handled = new Set<string>()
+    const folders = args.sources.filter(sourceIsFolder)
+    const sources: string[] = []
+
+    for (const source of args.sources) {
+        if (handled.has(source)) continue
+        handled.add(source)
+        if (folders.some((folder) => source.startsWith(folder)) && !sourceIsFolder(source)) {
+            continue
+        }
+        sources.push(source)
+    }
+
+    return sources
+}
+
+export function buildCopyVerifyPlan(args: CopyArgs): CopyVerifyPlan {
+    const copyInputs = buildCopyInputs(args)
+    const sources = effectiveSources(args)
+
+    if (copyInputs.length !== sources.length) {
+        throw new Error('Unable to map effective Copy inputs to verification units')
+    }
+
+    const configParam = verificationConfig(args)
+    const units: TransferUnit[] = sources.map((source, index) => {
+        const copyInput = copyInputs[index]
+        const sourceInfo = getFsInfo(source)
+        return {
+            id: `unit-${index + 1}`,
+            kind: sourceInfo.type === 'folder' ? 'folder' : 'file',
+            sourceDisplayPath: source,
+            destinationDisplayPath: destinationObjectPath(args.destination, sourceInfo.name),
+            copyInput,
+            verificationInput: buildVerificationInput(args, source, copyInput, configParam),
+        }
+    })
+
+    const destinations = new Map<string, TransferUnit>()
+    for (const unit of units) {
+        const key = normalizePathForComparison(unit.destinationDisplayPath)
+        const existing = destinations.get(key)
+        if (existing) {
+            throw new Error(
+                `Copy + Verify destination collision: ${unit.destinationDisplayPath} is targeted by ${existing.sourceDisplayPath} and ${unit.sourceDisplayPath}`
+            )
+        }
+        destinations.set(key, unit)
+    }
+
+    return {
+        units,
+        copyInputs,
+        verificationInputs: units.map((unit) => unit.verificationInput),
+    }
+}
+
+export { escapeFilterLiteral }

--- a/lib/copyVerify/rclone.ts
+++ b/lib/copyVerify/rclone.ts
@@ -1,0 +1,93 @@
+import rclone from '../rclone/client'
+import type { BatchInput } from '../rclone/requests'
+import type { JobStatusLike } from './results'
+
+export interface SubmittedCopyVerifyJob {
+    jobId: number
+    executeId: string
+}
+
+export interface JobListSnapshot {
+    executeId: string
+    jobids: number[]
+    runningIds: number[]
+    finishedIds: number[]
+}
+
+export interface GroupStatsSnapshot {
+    checks?: number
+    [key: string]: unknown
+}
+
+function assertSubmittedJob(value: unknown): SubmittedCopyVerifyJob {
+    const response = value as { jobid?: unknown; executeId?: unknown }
+    if (typeof response?.jobid !== 'number' || typeof response.executeId !== 'string') {
+        throw new Error('rclone did not return a usable async job reference')
+    }
+    return { jobId: response.jobid, executeId: response.executeId }
+}
+
+export async function submitCopyVerifyBatch(
+    inputs: BatchInput[],
+    group: string
+): Promise<SubmittedCopyVerifyJob> {
+    const response = await rclone('/job/batch', {
+        body: {
+            inputs: inputs.map((input) => ({ ...input, _group: group })),
+            _async: true,
+        },
+    })
+    return assertSubmittedJob(response)
+}
+
+export async function getJobList(): Promise<JobListSnapshot> {
+    const response = (await rclone('/job/list', { body: {} })) as unknown as JobListSnapshot
+    if (!response || typeof response.executeId !== 'string' || !Array.isArray(response.jobids)) {
+        throw new Error('rclone returned an invalid job list')
+    }
+    return response
+}
+
+export async function getJobStatus(jobId: number): Promise<JobStatusLike> {
+    return (await rclone('/job/status', { body: { jobid: jobId } })) as unknown as JobStatusLike
+}
+
+export async function getGroupStats(group: string): Promise<GroupStatsSnapshot> {
+    return (await rclone('/core/stats', { body: { group } })) as unknown as GroupStatsSnapshot
+}
+
+export async function stopCopyVerifyGroup(group: string): Promise<void> {
+    await rclone('/job/stopgroup', { body: { group } })
+}
+
+export class RcloneDaemonChangedError extends Error {
+    constructor() {
+        super('The rclone daemon changed while Copy + Verify was running')
+        this.name = 'RcloneDaemonChangedError'
+    }
+}
+
+export async function waitForCopyVerifyJob(
+    job: SubmittedCopyVerifyJob,
+    options: { pollMs?: number; signal?: AbortSignal } = {}
+): Promise<JobStatusLike> {
+    const pollMs = options.pollMs ?? 500
+    while (true) {
+        if (options.signal?.aborted) throw new Error('Copy + Verify was stopped')
+        const list = await getJobList()
+        if (list.executeId !== job.executeId) throw new RcloneDaemonChangedError()
+        const status = await getJobStatus(job.jobId)
+        if (status.finished) return status
+        await new Promise<void>((resolve, reject) => {
+            const timeout = setTimeout(resolve, pollMs)
+            options.signal?.addEventListener(
+                'abort',
+                () => {
+                    clearTimeout(timeout)
+                    reject(new Error('Copy + Verify was stopped'))
+                },
+                { once: true }
+            )
+        })
+    }
+}

--- a/lib/copyVerify/repair.test.ts
+++ b/lib/copyVerify/repair.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import type { CopyVerifyOperation, TransferUnit } from '../../types/copyVerify'
+import { buildRepairInputs } from './repair'
+
+const fileUnit: TransferUnit = {
+    id: 'unit-1',
+    kind: 'file',
+    sourceDisplayPath: '/source/report.txt',
+    destinationDisplayPath: '/destination/report.txt',
+    copyInput: {
+        _path: 'operations/copyfile',
+        srcFs: ':local:/source',
+        srcRemote: 'report.txt',
+        dstFs: ':local:/destination',
+        dstRemote: 'report.txt',
+    },
+    verificationInput: {
+        _path: 'operations/check',
+        srcFs: ':local:/source',
+        dstFs: ':local:/destination',
+    },
+}
+
+const operation: CopyVerifyOperation = {
+    id: 'operation-1',
+    hostId: 'local',
+    sources: ['/source/report.txt'],
+    destination: '/destination/',
+    createdAt: '2026-08-17T00:00:00.000Z',
+    updatedAt: '2026-08-17T00:00:00.000Z',
+    phase: 'complete',
+    result: 'verification_failed',
+    filesChecked: 1,
+    missingFiles: [{ unitId: 'unit-1', path: 'missing.txt' }],
+    differentFiles: [{ unitId: 'unit-1', path: 'report.txt' }],
+    errors: [{ unitId: 'unit-1', path: 'permission denied' }],
+    verificationJobs: [],
+    repairJobs: [],
+    transferUnits: [fileUnit],
+    executionOptions: {
+        copy: { ignore_existing: true, immutable: true },
+        config: { dry_run: true },
+        filter: {},
+        remotes: {},
+    },
+}
+
+describe('buildRepairInputs', () => {
+    it('repairs only missing and different paths with overwrite-safe options', () => {
+        const repair = buildRepairInputs(operation)
+
+        expect(repair.units).toEqual([fileUnit, fileUnit])
+        expect(repair.inputs).toHaveLength(2)
+        expect(repair.inputs.map((input) => input.dstRemote)).toEqual(['report.txt', 'report.txt'])
+        for (const input of repair.inputs) {
+            expect(input._config).toContain('"IgnoreExisting":false')
+            expect(input._config).toContain('"Immutable":false')
+            expect(input._config).toContain('"IgnoreTimes":true')
+            expect(input._config).toContain('"DryRun":false')
+        }
+    })
+
+    it('does not create repair inputs from error-only issues', () => {
+        const repair = buildRepairInputs({
+            ...operation,
+            missingFiles: [],
+            differentFiles: [],
+        })
+
+        expect(repair.inputs).toEqual([])
+        expect(repair.units).toEqual([])
+    })
+})

--- a/lib/copyVerify/repair.ts
+++ b/lib/copyVerify/repair.ts
@@ -1,0 +1,51 @@
+import type { CopyVerifyOperation, TransferUnit } from '../../types/copyVerify'
+import { type BatchInput, toConfigParam } from '../rclone/requests'
+
+function repairConfig(options: CopyVerifyOperation['executionOptions']): string | undefined {
+    return toConfigParam({
+        ...(options.copy || {}),
+        ...(options.config || {}),
+        ignore_existing: false,
+        immutable: false,
+        ignore_times: true,
+        dry_run: false,
+    })
+}
+
+export function buildRepairInputs(operation: CopyVerifyOperation): {
+    inputs: BatchInput[]
+    units: TransferUnit[]
+} {
+    const issues = [...operation.missingFiles, ...operation.differentFiles]
+    const configParam = repairConfig(operation.executionOptions)
+    const inputs: BatchInput[] = []
+    const units: TransferUnit[] = []
+
+    for (const issue of issues) {
+        const unit = operation.transferUnits.find((candidate) => candidate.id === issue.unitId)
+        if (!unit) continue
+        const copyInput = unit.copyInput
+        if (unit.kind === 'folder') {
+            inputs.push({
+                _path: 'operations/copyfile',
+                srcFs: copyInput.srcFs,
+                srcRemote: issue.path,
+                dstFs: copyInput.dstFs,
+                dstRemote: issue.path,
+                ...(configParam ? { _config: configParam } : {}),
+            })
+        } else {
+            inputs.push({
+                _path: 'operations/copyfile',
+                srcFs: copyInput.srcFs,
+                srcRemote: copyInput.srcRemote,
+                dstFs: copyInput.dstFs,
+                dstRemote: copyInput.dstRemote,
+                ...(configParam ? { _config: configParam } : {}),
+            })
+        }
+        units.push(unit)
+    }
+
+    return { inputs, units }
+}

--- a/lib/copyVerify/report.test.ts
+++ b/lib/copyVerify/report.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import type { CopyVerifyOperation } from '../../types/copyVerify'
+import { buildCopyReport } from './report'
+
+const operation: CopyVerifyOperation = {
+    id: 'operation-1',
+    hostId: 'local',
+    sources: ['/source/'],
+    destination: '/destination/',
+    createdAt: '2026-08-17T00:00:00.000Z',
+    updatedAt: '2026-08-17T00:01:00.000Z',
+    completedAt: '2026-08-17T00:01:00.000Z',
+    phase: 'complete',
+    result: 'verification_failed',
+    verificationMethod: { kind: 'checksum', hashTypes: ['md5'] },
+    filesChecked: 3,
+    missingFiles: [{ unitId: 'unit-1', path: 'missing[1].txt', message: 'not found' }],
+    differentFiles: [],
+    errors: [],
+    copyDurationSeconds: 1,
+    verificationDurationSeconds: 2,
+    totalDurationSeconds: 3,
+    verificationJobs: [],
+    repairJobs: [],
+    transferUnits: [],
+    executionOptions: {
+        copy: { secret_option: 'must not appear' },
+        config: {},
+        filter: {},
+        remotes: {},
+    },
+}
+
+describe('Copy + Verify report', () => {
+    it('contains contextual failures but no successful filenames or remote options', () => {
+        const report = buildCopyReport(operation)
+        expect(report).toContain('missing\\[1\\]\\.txt')
+        expect(report).toContain('Files checked: 3')
+        expect(report).not.toContain('secret_option')
+        expect(report).not.toContain('match.txt')
+    })
+})

--- a/lib/copyVerify/report.ts
+++ b/lib/copyVerify/report.ts
@@ -1,0 +1,89 @@
+import type { CopyVerifyOperation, VerificationIssue } from '../../types/copyVerify'
+
+function escapeMarkdown(value: string): string {
+    return value.replace(/[\\`*_{}\[\]()#+.!|>~-]/g, '\\$&')
+}
+
+function renderIssues(title: string, issues: VerificationIssue[]): string[] {
+    const lines = [`### ${title}`]
+    if (issues.length === 0) {
+        lines.push('None')
+        return lines
+    }
+    for (const issue of issues) {
+        lines.push(
+            `- \`${escapeMarkdown(issue.unitId)}\` — \`${escapeMarkdown(issue.path)}\`${issue.message ? ` — ${escapeMarkdown(issue.message)}` : ''}`
+        )
+    }
+    return lines
+}
+
+function formatDuration(seconds: number | undefined): string {
+    return seconds === undefined ? 'Unavailable' : `${seconds.toFixed(2)} seconds`
+}
+
+function renderJobRefs(operation: CopyVerifyOperation): string[] {
+    const lines = ['### Job references']
+    if (operation.copyJob) {
+        lines.push(
+            `- Copy: job ${operation.copyJob.jobId}, group \`${escapeMarkdown(operation.copyJob.group)}\`, attempt ${operation.copyJob.attempt}`
+        )
+    }
+    for (const job of operation.verificationJobs) {
+        lines.push(
+            `- Verification: job ${job.jobId}, group \`${escapeMarkdown(job.group)}\`, attempt ${job.attempt}`
+        )
+    }
+    for (const job of operation.repairJobs) {
+        lines.push(
+            `- Repair: job ${job.jobId}, group \`${escapeMarkdown(job.group)}\`, attempt ${job.attempt}`
+        )
+    }
+    if (lines.length === 1) lines.push('Unavailable')
+    return lines
+}
+
+export function verificationMethodLabel(operation: CopyVerifyOperation): string {
+    const method = operation.verificationMethod
+    if (!method) return 'Unavailable'
+    if (method.kind === 'checksum') {
+        return `Checksum (${method.hashTypes.join(', ') || 'rclone-reported'}) — rclone-reported`
+    }
+    if (method.kind === 'size_only') return 'Size only — rclone-reported'
+    if (method.kind === 'mixed') {
+        return `Mixed checksum/size-only (${method.hashTypes.join(', ') || 'rclone-reported'}) — rclone-reported`
+    }
+    return `Unknown method (${method.hashTypes.join(', ') || 'not reported'}) — rclone-reported`
+}
+
+export function buildCopyReport(operation: CopyVerifyOperation): string {
+    const result = operation.result
+        ? operation.result.replace(/_/g, ' ').toUpperCase()
+        : 'IN PROGRESS'
+    const lines = [
+        '# Copy + Verify report',
+        '',
+        `- Operation ID: \`${escapeMarkdown(operation.id)}\``,
+        `- Result: ${escapeMarkdown(result)}`,
+        `- Phase: ${escapeMarkdown(operation.phase)}`,
+        `- Created: ${escapeMarkdown(operation.createdAt)}`,
+        `- Updated: ${escapeMarkdown(operation.updatedAt)}`,
+        `- Completed: ${operation.completedAt ? escapeMarkdown(operation.completedAt) : 'Not completed'}`,
+        `- Sources: ${operation.sources.map((source) => `\`${escapeMarkdown(source)}\``).join(', ')}`,
+        `- Destination: \`${escapeMarkdown(operation.destination)}\``,
+        `- Verification method: ${escapeMarkdown(verificationMethodLabel(operation))}`,
+        `- Files checked: ${operation.filesChecked === null ? 'Unavailable' : operation.filesChecked}`,
+        `- Copy duration: ${formatDuration(operation.copyDurationSeconds)}`,
+        `- Verification duration: ${formatDuration(operation.verificationDurationSeconds)}`,
+        `- Total duration: ${formatDuration(operation.totalDurationSeconds)}`,
+        '',
+        ...renderJobRefs(operation),
+        '',
+        ...renderIssues('Missing files', operation.missingFiles),
+        '',
+        ...renderIssues('Different files', operation.differentFiles),
+        '',
+        ...renderIssues('Errors', operation.errors),
+    ]
+    return lines.join('\n')
+}

--- a/lib/copyVerify/results.test.ts
+++ b/lib/copyVerify/results.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import type { TransferUnit } from '../../types/copyVerify'
+import {
+    aggregateCopyResult,
+    aggregateVerificationResult,
+    classifyVerificationMethod,
+    recoverFilesChecked,
+} from './results'
+
+const units: TransferUnit[] = [
+    {
+        id: 'unit-1',
+        kind: 'folder',
+        sourceDisplayPath: '/source/',
+        destinationDisplayPath: '/destination/source',
+        copyInput: { _path: 'sync/copy' },
+        verificationInput: { _path: 'operations/check' },
+    },
+]
+
+describe('Copy + Verify result aggregation', () => {
+    it('requires every copy child to succeed', () => {
+        const result = aggregateCopyResult(
+            {
+                finished: true,
+                output: { results: [{ success: true }, { error: 'permission denied' }] },
+            },
+            2,
+            [units[0], { ...units[0], id: 'unit-2' }]
+        )
+
+        expect(result.success).toBe(false)
+        expect(result.errors[0]).toMatchObject({ unitId: 'unit-2', message: 'permission denied' })
+    })
+
+    it('rejects incomplete copy output even when the job says success', () => {
+        const result = aggregateCopyResult(
+            { finished: true, success: true, output: { results: [{ success: true }] } },
+            2,
+            [units[0], { ...units[0], id: 'unit-2' }]
+        )
+        expect(result.success).toBe(false)
+        expect(result.message).toContain('returned 1 results')
+    })
+
+    it('rejects malformed copy children instead of inferring success', () => {
+        const result = aggregateCopyResult({ finished: true, output: { results: [{}] } }, 1, units)
+
+        expect(result.success).toBe(false)
+        expect(result.errors[0]).toMatchObject({
+            unitId: 'unit-1',
+            message: 'Copy child did not report success',
+        })
+    })
+
+    it.each([
+        [['md5'], 'checksum'],
+        [['none'], 'size_only'],
+        [['md5', 'none'], 'mixed'],
+        [[undefined, 'md5'], 'unknown'],
+    ])('classifies hash coverage %#', (hashTypes, expected) => {
+        expect(classifyVerificationMethod(hashTypes as Array<string | undefined>).kind).toBe(
+            expected
+        )
+    })
+
+    it('aggregates missing, differing, and read errors with unit context', () => {
+        const result = aggregateVerificationResult(
+            {
+                finished: true,
+                output: {
+                    results: [
+                        {
+                            output: {
+                                success: false,
+                                hashType: 'md5',
+                                missingOnDst: ['missing.txt'],
+                                differ: ['changed.txt'],
+                                error: ['unreadable.txt'],
+                            },
+                        },
+                    ],
+                },
+            },
+            units
+        )
+
+        expect(result.success).toBe(false)
+        expect(result.method.kind).toBe('checksum')
+        expect(result.missingFiles).toEqual([{ unitId: 'unit-1', path: 'missing.txt' }])
+        expect(result.differentFiles).toEqual([{ unitId: 'unit-1', path: 'changed.txt' }])
+        expect(result.errors).toEqual([{ unitId: 'unit-1', path: 'unreadable.txt' }])
+    })
+
+    it('does not turn missing or differing files into generic read errors', () => {
+        const result = aggregateVerificationResult(
+            {
+                finished: true,
+                output: {
+                    results: [
+                        {
+                            output: {
+                                success: false,
+                                hashType: 'md5',
+                                missingOnDst: ['missing.txt'],
+                                differ: ['changed.txt'],
+                            },
+                        },
+                    ],
+                },
+            },
+            units
+        )
+
+        expect(result.errors).toEqual([])
+        expect(result.success).toBe(false)
+    })
+
+    it('does not invent a checked-file count', () => {
+        expect(recoverFilesChecked({ checks: 12 })).toBe(12)
+        expect(recoverFilesChecked({ checks: '12' })).toBeNull()
+        expect(recoverFilesChecked({})).toBeNull()
+    })
+})

--- a/lib/copyVerify/results.ts
+++ b/lib/copyVerify/results.ts
@@ -1,0 +1,240 @@
+import type {
+    CopyVerifyOperation,
+    TransferUnit,
+    VerificationIssue,
+    VerificationMethod,
+} from '../../types/copyVerify'
+
+export interface BatchChildResult {
+    error?: unknown
+    success?: boolean
+    input?: Record<string, unknown>
+    output?: unknown
+    [key: string]: unknown
+}
+
+export interface JobStatusLike {
+    finished?: boolean
+    success?: boolean
+    error?: unknown
+    output?: unknown
+    duration?: number
+    startTime?: string
+    endTime?: string
+}
+
+export interface CopyAggregation {
+    success: boolean
+    errors: VerificationIssue[]
+    message?: string
+}
+
+export interface VerificationAggregation {
+    success: boolean
+    method: VerificationMethod
+    missingFiles: VerificationIssue[]
+    differentFiles: VerificationIssue[]
+    errors: VerificationIssue[]
+    message?: string
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === 'object' ? (value as Record<string, unknown>) : null
+}
+
+function stringValue(value: unknown): string {
+    if (typeof value === 'string') return value
+    if (value instanceof Error) return value.message
+    try {
+        return JSON.stringify(value) ?? String(value)
+    } catch {
+        return String(value)
+    }
+}
+
+export function extractBatchResults(output: unknown): BatchChildResult[] | null {
+    const record = asRecord(output)
+    if (Array.isArray(record?.results)) {
+        return record.results.map((result) => asRecord(result) ?? {})
+    }
+    if (Array.isArray(output)) {
+        return output.map((result) => asRecord(result) ?? {})
+    }
+    return null
+}
+
+export function aggregateCopyResult(
+    status: JobStatusLike,
+    expectedInputCount: number,
+    units: TransferUnit[]
+): CopyAggregation {
+    if (!status.finished) {
+        return { success: false, errors: [], message: 'Copy job did not finish' }
+    }
+
+    if (status.error) {
+        return { success: false, errors: [], message: stringValue(status.error) }
+    }
+
+    const results = extractBatchResults(status.output)
+    if (!results || results.length !== expectedInputCount) {
+        return {
+            success: false,
+            errors: [],
+            message: `Copy returned ${results?.length ?? 0} results for ${expectedInputCount} submitted inputs`,
+        }
+    }
+
+    const errors: VerificationIssue[] = []
+    results.forEach((result, index) => {
+        const error =
+            result.error ??
+            (result.success !== true ? 'Copy child did not report success' : undefined)
+        if (error) {
+            errors.push({
+                unitId: units[index]?.id ?? `unit-${index + 1}`,
+                path: String(result.input?.srcRemote ?? result.input?.dstRemote ?? 'unknown'),
+                message: stringValue(error),
+            })
+        }
+    })
+
+    const parentFailed = status.success === false
+    return {
+        success: errors.length === 0 && !parentFailed,
+        errors,
+        ...(parentFailed && errors.length === 0 ? { message: 'Copy batch reported failure' } : {}),
+    }
+}
+
+function unwrapCheckResult(result: BatchChildResult): Record<string, unknown> | null {
+    const nested = asRecord(result.output)
+    return nested ?? result
+}
+
+function issueList(value: unknown, unitId: string, fallbackMessage?: string): VerificationIssue[] {
+    if (value === undefined || value === null || value === false) return []
+    if (!Array.isArray(value)) {
+        return [
+            {
+                unitId,
+                path: 'error',
+                message: fallbackMessage ?? stringValue(value),
+            },
+        ]
+    }
+    return value.map((entry) => {
+        if (typeof entry === 'string') return { unitId, path: entry, message: fallbackMessage }
+        const record = asRecord(entry)
+        return {
+            unitId,
+            path: String(record?.path ?? record?.Path ?? record?.name ?? entry),
+            ...(record?.message || fallbackMessage
+                ? { message: String(record?.message ?? fallbackMessage) }
+                : {}),
+        }
+    })
+}
+
+function classifyHashTypes(hashTypes: Array<string | undefined>): VerificationMethod {
+    const normalized = hashTypes.map((hash) => hash?.trim().toLowerCase() ?? '')
+    const unique = [...new Set(hashTypes.filter((hash): hash is string => !!hash?.trim()))]
+    if (normalized.some((hash) => !hash || hash === 'unknown' || hash === 'unavailable')) {
+        return { kind: 'unknown', hashTypes: unique }
+    }
+    const hasNone = normalized.some((hash) => hash === 'none')
+    const realHashes = normalized.filter((hash) => hash !== 'none')
+    if (realHashes.length === 0) return { kind: 'size_only', hashTypes: [] }
+    if (hasNone) return { kind: 'mixed', hashTypes: unique }
+    return { kind: 'checksum', hashTypes: unique }
+}
+
+export function classifyVerificationMethod(
+    hashTypes: Array<string | undefined>
+): VerificationMethod {
+    return classifyHashTypes(hashTypes)
+}
+
+export function aggregateVerificationResult(
+    status: JobStatusLike,
+    units: TransferUnit[]
+): VerificationAggregation {
+    const emptyMethod = classifyHashTypes([])
+    if (!status.finished) {
+        return {
+            success: false,
+            method: emptyMethod,
+            missingFiles: [],
+            differentFiles: [],
+            errors: [],
+            message: 'Verification job did not finish',
+        }
+    }
+
+    const results = extractBatchResults(status.output)
+    if (!results || results.length !== units.length) {
+        return {
+            success: false,
+            method: emptyMethod,
+            missingFiles: [],
+            differentFiles: [],
+            errors: [],
+            message: `Verification returned ${results?.length ?? 0} results for ${units.length} submitted inputs`,
+        }
+    }
+
+    const missingFiles: VerificationIssue[] = []
+    const differentFiles: VerificationIssue[] = []
+    const errors: VerificationIssue[] = []
+    const hashTypes: Array<string | undefined> = []
+
+    results.forEach((result, index) => {
+        const unitId = units[index]?.id ?? `unit-${index + 1}`
+        const output = unwrapCheckResult(result)
+        if (!output) {
+            errors.push({ unitId, path: 'unknown', message: 'Missing structured check result' })
+            return
+        }
+
+        hashTypes.push(typeof output.hashType === 'string' ? output.hashType : undefined)
+        missingFiles.push(...issueList(output.missingOnDst, unitId))
+        differentFiles.push(...issueList(output.differ, unitId))
+        errors.push(...issueList(output.error, unitId))
+
+        const hasUnitIssue =
+            errors.some((issue) => issue.unitId === unitId) ||
+            missingFiles.some((issue) => issue.unitId === unitId) ||
+            differentFiles.some((issue) => issue.unitId === unitId)
+        if (output.success !== true && !hasUnitIssue) {
+            const message =
+                typeof output.status === 'string' ? output.status : 'Verification failed'
+            errors.push({ unitId, path: 'verification', message })
+        }
+    })
+
+    if (status.error) {
+        errors.push({
+            unitId: 'operation',
+            path: 'verification',
+            message: stringValue(status.error),
+        })
+    }
+
+    return {
+        success: errors.length === 0 && missingFiles.length === 0 && differentFiles.length === 0,
+        method: classifyHashTypes(hashTypes),
+        missingFiles,
+        differentFiles,
+        errors,
+    }
+}
+
+export function recoverFilesChecked(stats: unknown): number | null {
+    const record = asRecord(stats)
+    const checks = record?.checks
+    return typeof checks === 'number' && Number.isFinite(checks) && checks >= 0 ? checks : null
+}
+
+export function operationHasRepairableIssues(operation: CopyVerifyOperation): boolean {
+    return operation.missingFiles.length > 0 || operation.differentFiles.length > 0
+}

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,11 +1,16 @@
 import { getCurrentWindow } from '@tauri-apps/api/window'
 import type { ConfigFile } from '../types/config'
+import type { CopyVerifyOperation } from '../types/copyVerify'
+import type { CopyArgs } from './rclone/requests'
 
 // Wire names for the cross-window app-lifecycle events. These strings cross the Tauri event bus
 // and are listened for in main.ts (loaded only by the hidden 'main' window) — keep them stable.
 export const CLOSE_APP = 'close-app'
 export const RELAUNCH_APP = 'relaunch-app'
 export const RESTART_RCLONE = 'restart-rclone'
+export const COPY_VERIFY_COMMAND = 'copy-verify-command'
+export const COPY_VERIFY_ACK = 'copy-verify-ack'
+export const COPY_VERIFY_UPDATED = 'copy-verify-updated'
 
 // Full lifecycle snapshot carried on a restart request. The main window may not have rehydrated
 // the initiating webview's store writes yet, so the intended values ride along in the payload.
@@ -21,10 +26,26 @@ export interface RestartRclonePayload {
     syncConfigLinkTarget?: string | null
 }
 
+export type CopyVerifyCommand =
+    | { type: 'start'; requestId: string; args: CopyArgs }
+    | { type: 'repair'; requestId: string; operationId: string }
+    | { type: 'verify-again'; requestId: string; operationId: string }
+    | { type: 'stop'; requestId: string; operationId: string }
+
+export interface CopyVerifyAck {
+    requestId: string
+    ok: boolean
+    operationId?: string
+    error?: string
+}
+
 export type AppEventPayload = {
     [CLOSE_APP]: undefined
     [RELAUNCH_APP]: undefined
     [RESTART_RCLONE]: RestartRclonePayload
+    [COPY_VERIFY_COMMAND]: CopyVerifyCommand
+    [COPY_VERIFY_ACK]: CopyVerifyAck
+    [COPY_VERIFY_UPDATED]: CopyVerifyOperation
 }
 
 // Emit an app-lifecycle event. Tauri's window.emit broadcasts globally, so the single main-window

--- a/lib/rclone/requests.ts
+++ b/lib/rclone/requests.ts
@@ -403,7 +403,12 @@ function buildTransferInputs(
     return inputs
 }
 
-export function buildCopyRequests(args: CopyArgs): RcRequest[] {
+/**
+ * Builds the effective copy inputs without wrapping them in an RC request. Copy + Verify uses
+ * this exact fan-out so the existing Copy route and the new workflow cannot disagree about which
+ * source objects are submitted.
+ */
+export function buildCopyInputs(args: CopyArgs): BatchInput[] {
     assertIncludeRules(args.sources, args.options.filter)
     assertFolderFilters(args.sources, args.options.filter)
     const configParam = toConfigParam({
@@ -411,12 +416,20 @@ export function buildCopyRequests(args: CopyArgs): RcRequest[] {
         ...(args.options.config || {}),
     })
     const filterParam = toFilterParam(args.options.filter)
-    const inputs = buildTransferInputs(
+    return buildTransferInputs(
         args,
         { folder: 'sync/copy', file: 'operations/copyfile' },
         configParam,
         filterParam
     )
+}
+
+export function buildCopyRequests(args: CopyArgs): RcRequest[] {
+    const inputs = buildCopyInputs(args)
+    const configParam = toConfigParam({
+        ...(args.options.copy || {}),
+        ...(args.options.config || {}),
+    })
     return [
         {
             endpoint: '/job/batch',

--- a/main.ts
+++ b/main.ts
@@ -10,6 +10,7 @@ import { platform } from '@tauri-apps/plugin-os'
 import { exit, relaunch } from '@tauri-apps/plugin-process'
 import { type Update, check } from '@tauri-apps/plugin-updater'
 import { defaultOptions } from 'tauri-plugin-sentry-api'
+import { type CopyVerifyCoordinator, initCopyVerifyCoordinator } from './lib/copyVerify/coordinator'
 import { getDeepLinkUrl, handleDeepLinkUrl } from './lib/deep'
 import { CLOSE_APP, RELAUNCH_APP, RESTART_RCLONE, type RestartRclonePayload } from './lib/events'
 import { LOCAL_HOST_ID, RC_PORT, getHostInfo, makeLocalHost } from './lib/hosts'
@@ -35,6 +36,25 @@ import { useStore } from './store/memory'
 import { selectCurrentHost, usePersistedStore } from './store/persisted'
 
 let rcloneListenersRegistered = false
+let copyVerifyCoordinator: CopyVerifyCoordinator | null = null
+let mainHostStoreReady = false
+
+usePersistedStore.subscribe((state, previousState) => {
+    if (
+        !mainHostStoreReady ||
+        !state.currentHostId ||
+        state.currentHostId === previousState.currentHostId
+    )
+        return
+    switchCopyVerifyHostStore(state.currentHostId).catch((error) =>
+        console.error('[main] failed to switch Copy + Verify host store', error)
+    )
+})
+
+async function switchCopyVerifyHostStore(hostId: string): Promise<void> {
+    await copyVerifyCoordinator?.markHostChanged()
+    await initHostStore(hostId)
+}
 
 // Mirrors zookeeper.rs RcloneEvent — only 'close' is emitted.
 type RcloneDaemonEvent = {
@@ -129,6 +149,7 @@ async function initializeHostStore() {
     const hostId = usePersistedStore.getState().currentHostId || LOCAL_HOST_ID
 
     await initHostStore(hostId)
+    mainHostStoreReady = true
 
     console.log('[initializeHostStore] initialized for', hostId)
 }
@@ -401,6 +422,7 @@ async function registerRcloneWindowListeners() {
             // Loop so a request that arrived (and applied its state) mid-restart still takes effect.
             do {
                 useStore.setState({ rcloneRestartPending: false })
+                await copyVerifyCoordinator?.markDaemonRestarted()
                 await killRcloneDaemon()
 
                 // Jobids do not survive a daemon restart — polling them would only 404.
@@ -882,6 +904,9 @@ waitForHydration()
     .then(() => checkAlreadyRunning())
     .then(() => startRclone())
     .then(() => checkRclone())
+    .then(async () => {
+        copyVerifyCoordinator = await initCopyVerifyCoordinator()
+    })
     .then(() => reconcileNotificationTargets())
     .then(() => initJobWatcher())
     .then(() => handleDeepLink())

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
                 "tailwindcss": "^3.4.17",
                 "typescript": "~5.9.3",
                 "vite": "^6.3.6",
+                "vitest": "^4.1.10",
                 "yaml": "^2.9.0"
             }
         },
@@ -125,6 +126,7 @@
             "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.27.1",
@@ -2128,6 +2130,7 @@
             "resolved": "https://registry.npmjs.org/@heroui/system/-/system-2.4.18.tgz",
             "integrity": "sha512-KYRCeA5JJXiGQZ1VJ1aHPOVy23U48Sf3z1ezVBZHnm6/7pn3c1lyqFapyL5qNkpzZ7c2s99b1Klik67KN8mLiQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@heroui/react-utils": "2.1.11",
                 "@heroui/system-rsc": "2.3.15",
@@ -2215,6 +2218,7 @@
             "resolved": "https://registry.npmjs.org/@heroui/theme/-/theme-2.4.17.tgz",
             "integrity": "sha512-I11ylsSsykVeQwEqMc8MyJy61zOOR68ilMCRXr7spQefSfwApuzQbFfxt5Tl/txlA3jo3j1Y97use0bm3stzCA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@heroui/shared-utils": "2.1.9",
                 "clsx": "^1.2.1",
@@ -2609,9 +2613,10 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.29",
@@ -5567,6 +5572,13 @@
                 "node": ">=18"
             }
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@swc/helpers": {
             "version": "0.5.17",
             "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
@@ -5618,6 +5630,7 @@
             "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.2.tgz",
             "integrity": "sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@tanstack/query-core": "5.101.2"
             },
@@ -6057,6 +6070,24 @@
                 "@babel/types": "^7.20.7"
             }
         },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/estree": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -6069,6 +6100,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.7.tgz",
             "integrity": "sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.20.0"
             }
@@ -6094,6 +6126,7 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
             "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
             "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
@@ -6127,6 +6160,92 @@
             },
             "peerDependencies": {
                 "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+            }
+        },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+            "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+            "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+            "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.10",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+            "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+            "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+            "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/abs-svg-path": {
@@ -6178,6 +6297,16 @@
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
             "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
+        },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/autoprefixer": {
             "version": "10.5.2",
@@ -6342,6 +6471,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.38",
                 "caniuse-lite": "^1.0.30001799",
@@ -6401,6 +6531,16 @@
             "license": "BSD-3-Clause",
             "peerDependencies": {
                 "react": ">=17.0.0"
+            }
+        },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/chokidar": {
@@ -6614,7 +6754,6 @@
             "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
             "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -6656,6 +6795,13 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
             "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+            "license": "MIT"
+        },
+        "node_modules/es-module-lexer": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+            "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/esbuild": {
@@ -6710,6 +6856,16 @@
                 "node": ">=6"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
         "node_modules/events": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -6717,6 +6873,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.x"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+            "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/fast-deep-equal": {
@@ -6836,6 +7002,7 @@
             "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.2.tgz",
             "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "motion-dom": "^12.42.2",
                 "motion-utils": "^12.39.0",
@@ -7222,6 +7389,16 @@
                 "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
         "node_modules/media-chrome": {
             "version": "4.19.0",
             "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.19.0.tgz",
@@ -7385,11 +7562,26 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/obug": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+            "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20.0"
+            }
+        },
         "node_modules/openapi-fetch": {
             "version": "0.17.0",
             "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.17.0.tgz",
             "integrity": "sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "openapi-typescript-helpers": "^0.1.0"
             }
@@ -7478,6 +7670,13 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
         },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7554,6 +7753,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.12",
                 "picocolors": "^1.1.1",
@@ -7747,6 +7947,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -7758,6 +7959,7 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -8036,6 +8238,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/signal-exit": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -8063,6 +8272,20 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/string_decoder": {
             "version": "1.3.0",
@@ -8369,15 +8592,32 @@
             "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
             "license": "MIT"
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+            "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/tinyglobby": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -8387,11 +8627,14 @@
             }
         },
         "node_modules/tinyglobby/node_modules/fdir": {
-            "version": "6.4.6",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-            "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
             "peerDependencies": {
                 "picomatch": "^3 || ^4"
             },
@@ -8402,16 +8645,27 @@
             }
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+            "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/to-regex-range": {
@@ -8455,6 +8709,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -8613,6 +8868,7 @@
             "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",
@@ -9201,6 +9457,137 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/vitest": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+            "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.1.10",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/runner": "4.1.10",
+                "@vitest/snapshot": "4.1.10",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.10",
+                "@vitest/browser-preview": "4.1.10",
+                "@vitest/browser-webdriverio": "4.1.10",
+                "@vitest/coverage-istanbul": "4.1.10",
+                "@vitest/coverage-v8": "4.1.10",
+                "@vitest/ui": "4.1.10",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/@vitest/mocker": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+            "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.10",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -9220,6 +9607,23 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -12,11 +12,21 @@
         "url": "https://github.com/rclone-ui/rclone-ui"
     },
     "homepage": "https://rcloneui.com",
-    "keywords": ["rclone", "gui", "drive", "s3", "cloud", "storage", "sync", "backup"],
+    "keywords": [
+        "rclone",
+        "gui",
+        "drive",
+        "s3",
+        "cloud",
+        "storage",
+        "sync",
+        "backup"
+    ],
     "license": "Apache-2.0",
     "scripts": {
         "dev": "node scripts/buildExternal.js && vite",
         "build": "node scripts/buildExternal.js && tsc && vite build",
+        "test": "vitest run --passWithNoTests",
         "preview": "node scripts/buildExternal.js && vite preview",
         "tauri": "tauri",
         "info": "tauri info",
@@ -89,6 +99,7 @@
         "tailwindcss": "^3.4.17",
         "typescript": "~5.9.3",
         "vite": "^6.3.6",
+        "vitest": "^4.1.10",
         "yaml": "^2.9.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -12,21 +12,13 @@
         "url": "https://github.com/rclone-ui/rclone-ui"
     },
     "homepage": "https://rcloneui.com",
-    "keywords": [
-        "rclone",
-        "gui",
-        "drive",
-        "s3",
-        "cloud",
-        "storage",
-        "sync",
-        "backup"
-    ],
+    "keywords": ["rclone", "gui", "drive", "s3", "cloud", "storage", "sync", "backup"],
     "license": "Apache-2.0",
     "scripts": {
         "dev": "node scripts/buildExternal.js && vite",
         "build": "node scripts/buildExternal.js && tsc && vite build",
         "test": "vitest run --passWithNoTests",
+        "test:local-rclone": "node scripts/copy-verify-local-integration.mjs",
         "preview": "node scripts/buildExternal.js && vite preview",
         "tauri": "tauri",
         "info": "tauri info",

--- a/scripts/buildExternal.js
+++ b/scripts/buildExternal.js
@@ -55,6 +55,14 @@ async function buildExternal() {
                 })
                 await Promise.all(jsFiles.map((file) => unlink(file).catch(() => {})))
             })(),
+            // Remove emitted types/*.js files introduced when runtime TypeScript imports a type module.
+            (async () => {
+                const jsFiles = await glob('**/*.js', {
+                    cwd: join(projectRoot, 'types'),
+                    absolute: true,
+                })
+                await Promise.all(jsFiles.map((file) => unlink(file).catch(() => {})))
+            })(),
             // Remove main.js
             unlink(join(projectRoot, 'main.js')).catch(() => {}), // Ignore if file doesn't exist
         ])

--- a/scripts/copy-verify-local-integration.mjs
+++ b/scripts/copy-verify-local-integration.mjs
@@ -1,0 +1,206 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawn } from 'node:child_process'
+import { createServer } from 'node:net'
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function freePort() {
+    const server = createServer()
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const port = server.address().port
+    await new Promise((resolve) => server.close(resolve))
+    return port
+}
+
+async function waitForRclone(baseUrl) {
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+        try {
+            const response = await fetch(`${baseUrl}/core/version`, {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: '{}',
+            })
+            if (response.ok) return
+        } catch {}
+        await wait(100)
+    }
+    throw new Error('Timed out waiting for the temporary rclone rcd')
+}
+
+async function post(baseUrl, path, body) {
+    const response = await fetch(`${baseUrl}${path}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+    })
+    const data = await response.json()
+    if (!response.ok || data.error) throw new Error(`${path}: ${data.error ?? response.statusText}`)
+    return data
+}
+
+async function runJob(baseUrl, inputs, group) {
+    const submitted = await post(baseUrl, '/job/batch', {
+        inputs: inputs.map((input) => ({ ...input, _group: group })),
+        _async: true,
+    })
+    assert.equal(typeof submitted.jobid, 'number')
+    assert.equal(typeof submitted.executeId, 'string')
+
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+        const status = await post(baseUrl, '/job/status', { jobid: submitted.jobid })
+        assert.equal(status.executeId, submitted.executeId)
+        if (status.finished) return { submitted, status }
+        await wait(25)
+    }
+    throw new Error(`Job ${submitted.jobid} did not finish`)
+}
+
+function localFs(path) {
+    return `:local:${path}`
+}
+
+function copyInput(src, dst) {
+    return { _path: 'sync/copy', srcFs: `${localFs(src)}/`, dstFs: `${localFs(dst)}/` }
+}
+
+function checkInput(src, dst, filter) {
+    return {
+        _path: 'operations/check',
+        srcFs: `${localFs(src)}/`,
+        dstFs: `${localFs(dst)}/`,
+        oneWay: true,
+        missingOnDst: true,
+        differ: true,
+        error: true,
+        match: false,
+        ...(filter ? { _filter: JSON.stringify({ IncludeRule: [filter] }) } : {}),
+    }
+}
+
+async function main() {
+    const root = await mkdtemp(join(tmpdir(), 'rclone-copy-verify-'))
+    const source = join(root, 'source')
+    const destination = join(root, 'destination')
+    const reservedSource = join(root, 'reserved-source')
+    const reservedDestination = join(root, 'reserved-destination')
+    await mkdir(source)
+    await mkdir(destination)
+    await mkdir(reservedSource)
+    await mkdir(reservedDestination)
+    await writeFile(join(source, 'a.txt'), 'same')
+    await writeFile(join(source, 'changed.txt'), 'source')
+    await writeFile(join(reservedSource, 'reserved[1]*?.txt'), 'reserved')
+
+    const port = await freePort()
+    const child = spawn(
+        'rclone',
+        [
+            'rcd',
+            '--rc-no-auth',
+            '--rc-addr',
+            `127.0.0.1:${port}`,
+            '--rc-job-expire-duration',
+            '2m',
+            '--rc-job-expire-interval',
+            '30s',
+        ],
+        { stdio: 'ignore' }
+    )
+    const baseUrl = `http://127.0.0.1:${port}`
+
+    try {
+        await waitForRclone(baseUrl)
+        const firstCopy = await runJob(baseUrl, [copyInput(source, destination)], 'copy-verify/test/copy')
+        assert.equal(firstCopy.status.success, true)
+
+        const verified = await runJob(
+            baseUrl,
+            [checkInput(source, destination)],
+            'copy-verify/test/verify/1'
+        )
+        const verifiedResult = verified.status.output.results[0]
+        assert.equal(verifiedResult.success, true)
+        assert.equal(verifiedResult.hashType, 'md5')
+
+        await writeFile(join(destination, 'extra.txt'), 'ignored by one-way')
+        const extraPass = await runJob(
+            baseUrl,
+            [checkInput(source, destination)],
+            'copy-verify/test/verify/extra'
+        )
+        assert.equal(extraPass.status.output.results[0].success, true)
+
+        await rm(join(destination, 'a.txt'))
+        const missing = await runJob(
+            baseUrl,
+            [checkInput(source, destination)],
+            'copy-verify/test/verify/missing'
+        )
+        assert.deepEqual(missing.status.output.results[0].missingOnDst, ['a.txt'])
+
+        await writeFile(join(destination, 'a.txt'), 'same')
+        await writeFile(join(destination, 'changed.txt'), 'different')
+        const differing = await runJob(
+            baseUrl,
+            [checkInput(source, destination)],
+            'copy-verify/test/verify/differ'
+        )
+        assert.deepEqual(differing.status.output.results[0].differ, ['changed.txt'])
+
+        const reservedCopy = await runJob(
+            baseUrl,
+            [
+                {
+                    _path: 'operations/copyfile',
+                    srcFs: localFs(reservedSource),
+                    srcRemote: 'reserved[1]*?.txt',
+                    dstFs: localFs(reservedDestination),
+                    dstRemote: 'reserved[1]*?.txt',
+                },
+            ],
+            'copy-verify/test/file/copy'
+        )
+        assert.equal(reservedCopy.status.success, true)
+        const reservedCheck = await runJob(
+            baseUrl,
+            [checkInput(reservedSource, reservedDestination, '/reserved\\[1\\]\\*\\?.txt')],
+            'copy-verify/test/file/verify'
+        )
+        assert.equal(reservedCheck.status.output.results[0].success, true)
+
+        const repair = await runJob(
+            baseUrl,
+            [
+                {
+                    _path: 'operations/copyfile',
+                    srcFs: localFs(source),
+                    srcRemote: 'changed.txt',
+                    dstFs: localFs(destination),
+                    dstRemote: 'changed.txt',
+                    _config: JSON.stringify({ IgnoreExisting: false, Immutable: false, IgnoreTimes: true }),
+                },
+            ],
+            'copy-verify/test/repair/1'
+        )
+        assert.equal(repair.status.success, true)
+        const repairedCheck = await runJob(
+            baseUrl,
+            [checkInput(source, destination)],
+            'copy-verify/test/verify/repaired'
+        )
+        assert.equal(repairedCheck.status.output.results[0].success, true)
+
+        console.log('local Copy + Verify rclone integration passed')
+    } finally {
+        child.kill('SIGTERM')
+        await rm(root, { recursive: true, force: true })
+    }
+}
+
+main().catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+})

--- a/src/components/CommandsDropdown.tsx
+++ b/src/components/CommandsDropdown.tsx
@@ -42,6 +42,7 @@ export default function CommandsDropdown({
                 <DropdownSection title={title ? undefined : 'Run another command'}>
                     <DropdownItem key="download">Download</DropdownItem>
                     <DropdownItem key="copy">Copy</DropdownItem>
+                    <DropdownItem key="copy-verify">Copy + Verify</DropdownItem>
                     <DropdownItem key="move">Move</DropdownItem>
                     <DropdownItem key="delete">Delete</DropdownItem>
                     <DropdownItem key="sync">Sync</DropdownItem>

--- a/src/components/copyVerify/CopyVerifyCard.tsx
+++ b/src/components/copyVerify/CopyVerifyCard.tsx
@@ -1,0 +1,68 @@
+import { Card, CardBody, Chip, Progress } from '@heroui/react'
+import { ChevronRightIcon } from 'lucide-react'
+import { buildReadablePathMultiple } from '../../../lib/format'
+import type { CopyVerifyOperation } from '../../../types/copyVerify'
+
+export function copyVerifyLabel(operation: CopyVerifyOperation): string {
+    if (operation.result === 'verified') return 'VERIFIED'
+    if (operation.result === 'verified_with_limitations') return 'VERIFIED WITH LIMITATIONS'
+    if (operation.result === 'verification_failed') return 'VERIFICATION FAILED'
+    if (operation.result === 'copy_failed') return 'COPY FAILED'
+    if (operation.result === 'cancelled') return 'CANCELLED'
+    if (operation.phase === 'verification_required') return 'VERIFICATION REQUIRED'
+    if (operation.phase === 'repairing') return 'REPAIRING'
+    if (operation.phase === 'verifying' || operation.phase === 'submitting_verification')
+        return 'VERIFYING'
+    return 'COPYING'
+}
+
+export default function CopyVerifyCard({
+    operation,
+    onSelect,
+}: {
+    operation: CopyVerifyOperation
+    onSelect: (operation: CopyVerifyOperation) => void
+}) {
+    const label = copyVerifyLabel(operation)
+    const isActive = !['complete', 'verification_required'].includes(operation.phase)
+    const progress =
+        operation.phase === 'verifying' || operation.phase === 'submitting_verification' ? 75 : 35
+
+    return (
+        <Card
+            radius="none"
+            shadow="none"
+            className="w-full border-b border-divider"
+            isPressable={true}
+            onPress={() => onSelect(operation)}
+            data-focus-visible="false"
+        >
+            <CardBody className="p-3">
+                <div className="flex items-center gap-3">
+                    <Chip
+                        color={
+                            isActive
+                                ? 'warning'
+                                : operation.result === 'verified'
+                                  ? 'success'
+                                  : 'danger'
+                        }
+                    >
+                        COPY + VERIFY
+                    </Chip>
+                    <div className="flex-1 min-w-0 text-left">
+                        <p className="font-bold truncate">
+                            {buildReadablePathMultiple(operation.sources, 'short', true)} →{' '}
+                            {operation.destination}
+                        </p>
+                        <p className="text-small text-foreground-500">{label}</p>
+                        {isActive ? (
+                            <Progress aria-label={label} value={progress} size="sm" />
+                        ) : null}
+                    </div>
+                    <ChevronRightIcon className="w-5 shrink-0" />
+                </div>
+            </CardBody>
+        </Card>
+    )
+}

--- a/src/components/copyVerify/CopyVerifyDetailsDrawer.tsx
+++ b/src/components/copyVerify/CopyVerifyDetailsDrawer.tsx
@@ -1,0 +1,172 @@
+import {
+    Button,
+    Drawer,
+    DrawerBody,
+    DrawerContent,
+    DrawerFooter,
+    DrawerHeader,
+} from '@heroui/react'
+import { writeText } from '@tauri-apps/plugin-clipboard-manager'
+import { message } from '@tauri-apps/plugin-dialog'
+import { useState } from 'react'
+import {
+    repairCopyVerify,
+    stopCopyVerify,
+    verifyAgainCopyVerify,
+} from '../../../lib/copyVerify/commands'
+import { buildCopyReport, verificationMethodLabel } from '../../../lib/copyVerify/report'
+import type { CopyVerifyOperation } from '../../../types/copyVerify'
+import { copyVerifyLabel } from './CopyVerifyCard'
+
+export default function CopyVerifyDetailsDrawer({
+    operation,
+    isOpen,
+    onClose,
+}: {
+    operation: CopyVerifyOperation
+    isOpen: boolean
+    onClose: () => void
+}) {
+    const [isBusy, setIsBusy] = useState(false)
+    const isActive = !['complete', 'verification_required'].includes(operation.phase)
+    const canRepair =
+        operation.result === 'verification_failed' &&
+        (operation.missingFiles.length > 0 || operation.differentFiles.length > 0)
+    const canVerifyAgain = operation.result !== 'copy_failed' && operation.result !== 'cancelled'
+
+    const run = async (action: () => Promise<void>, success: string) => {
+        setIsBusy(true)
+        try {
+            await action()
+            await message(success, { title: 'Copy + Verify', kind: 'info' })
+        } catch (error) {
+            await message(error instanceof Error ? error.message : String(error), {
+                title: 'Copy + Verify',
+                kind: 'error',
+            })
+        } finally {
+            setIsBusy(false)
+        }
+    }
+
+    const handleCopyReport = () => {
+        writeText(buildCopyReport(operation)).catch((error) =>
+            console.error('[CopyVerify] report copy failed', error)
+        )
+    }
+
+    const handleRepair = () => {
+        run(() => repairCopyVerify(operation.id), 'Repair submitted.').catch((error) =>
+            console.error('[CopyVerify] repair action failed', error)
+        )
+    }
+
+    const handleVerifyAgain = () => {
+        run(() => verifyAgainCopyVerify(operation.id), 'Verification submitted.').catch((error) =>
+            console.error('[CopyVerify] verify-again action failed', error)
+        )
+    }
+
+    const handleStop = () => {
+        run(() => stopCopyVerify(operation.id), 'Operation stopped.').catch((error) =>
+            console.error('[CopyVerify] stop action failed', error)
+        )
+    }
+
+    return (
+        <Drawer isOpen={isOpen} onClose={onClose} size="lg">
+            <DrawerContent>
+                <DrawerHeader className="flex flex-col gap-1">
+                    <span>Copy + Verify</span>
+                    <span className="text-small text-foreground-500">
+                        {copyVerifyLabel(operation)}
+                    </span>
+                </DrawerHeader>
+                <DrawerBody>
+                    <p>
+                        <strong>Operation ID:</strong> {operation.id}
+                    </p>
+                    <p>
+                        <strong>Sources:</strong> {operation.sources.join(', ')}
+                    </p>
+                    <p>
+                        <strong>Destination:</strong> {operation.destination}
+                    </p>
+                    <p>
+                        <strong>Files checked:</strong>{' '}
+                        {operation.filesChecked === null ? 'Unavailable' : operation.filesChecked}
+                    </p>
+                    <p>
+                        <strong>Method:</strong> {verificationMethodLabel(operation)}
+                    </p>
+                    {(operation.missingFiles.length > 0 ||
+                        operation.differentFiles.length > 0 ||
+                        operation.errors.length > 0) && (
+                        <div className="space-y-3">
+                            {operation.missingFiles.length > 0 ? (
+                                <IssueList
+                                    title="Missing files"
+                                    items={operation.missingFiles.map((item) => item.path)}
+                                />
+                            ) : null}
+                            {operation.differentFiles.length > 0 ? (
+                                <IssueList
+                                    title="Different files"
+                                    items={operation.differentFiles.map((item) => item.path)}
+                                />
+                            ) : null}
+                            {operation.errors.length > 0 ? (
+                                <IssueList
+                                    title="Errors"
+                                    items={operation.errors.map(
+                                        (item) => `${item.path}: ${item.message ?? 'unknown error'}`
+                                    )}
+                                />
+                            ) : null}
+                        </div>
+                    )}
+                </DrawerBody>
+                <DrawerFooter className="flex-wrap">
+                    <Button onPress={handleCopyReport} variant="flat">
+                        Copy Report
+                    </Button>
+                    {canRepair ? (
+                        <Button color="warning" isLoading={isBusy} onPress={handleRepair}>
+                            Repair Files and Recheck
+                        </Button>
+                    ) : null}
+                    {canVerifyAgain ? (
+                        <Button color="primary" isLoading={isBusy} onPress={handleVerifyAgain}>
+                            Verify Again
+                        </Button>
+                    ) : null}
+                    {isActive ? (
+                        <Button
+                            color="danger"
+                            variant="flat"
+                            isLoading={isBusy}
+                            onPress={handleStop}
+                        >
+                            Stop
+                        </Button>
+                    ) : null}
+                </DrawerFooter>
+            </DrawerContent>
+        </Drawer>
+    )
+}
+
+function IssueList({ title, items }: { title: string; items: string[] }) {
+    return (
+        <div>
+            <h3 className="font-semibold">{title}</h3>
+            <ul className="pl-5 list-disc">
+                {items.map((item, index) => (
+                    <li key={`${item}-${index}`} className="break-all">
+                        {item}
+                    </li>
+                ))}
+            </ul>
+        </div>
+    )
+}

--- a/src/components/operation/OperationFooter.tsx
+++ b/src/components/operation/OperationFooter.tsx
@@ -34,6 +34,7 @@ export default function OperationFooter({
     startIsPending,
     onStart,
     onSchedule,
+    showSchedule = true,
     dryRunIsPending,
     onDryRun,
     startBlocked,
@@ -56,6 +57,7 @@ export default function OperationFooter({
     startIsPending: boolean
     onStart: () => void
     onSchedule: () => void
+    showSchedule?: boolean
     // Present only on pages with a dry-run mutation (Copy/Sync/Move/Delete).
     dryRunIsPending?: boolean
     onDryRun?: () => void
@@ -199,7 +201,7 @@ export default function OperationFooter({
                         </Button>
                     </Tooltip>
                 ) : null}
-                {schedulingAvailable ? (
+                {showSchedule && schedulingAvailable ? (
                     <Tooltip content="Schedule task" placement="top" size="lg" color="foreground">
                         <Button
                             size="lg"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -95,6 +95,10 @@ const router = createBrowserRouter([
         element: <Copy />,
     },
     {
+        path: '/copy-verify',
+        element: <Copy mode="copy-verify" />,
+    },
+    {
         path: '/move',
         element: <Move />,
     },

--- a/src/pages/Copy.tsx
+++ b/src/pages/Copy.tsx
@@ -1,12 +1,16 @@
 import { useMutation } from '@tanstack/react-query'
+import { ask } from '@tauri-apps/plugin-dialog'
 import { AlertOctagonIcon, FoldersIcon, PlayIcon } from 'lucide-react'
 import { startTransition, useCallback, useEffect, useMemo, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
+import { startCopyVerify } from '../../lib/copyVerify/commands'
 import { onErrorDialog } from '../../lib/errors'
 import { getOptionsSubtitle } from '../../lib/flags'
+import { getRemoteName } from '../../lib/format'
 import { useFlags } from '../../lib/hooks'
 import { startCopy, startDryRun } from '../../lib/rclone/api'
 import { RCLONE_CONFIG_DEFAULTS } from '../../lib/rclone/constants'
+import type { CopyArgs } from '../../lib/rclone/requests'
 import { useSchedulingAvailable } from '../../lib/scheduler'
 import { usePersistedStore } from '../../store/persisted'
 import OperationWindowContent from '../components/OperationWindowContent'
@@ -53,7 +57,16 @@ Tap the folder icon in the bottom bar to load or save option presets. Templates 
 4. START THE COPY
 Once paths are selected, tap "START COPY" to begin. You can monitor progress on the Transfers page.`
 
-export default function Copy() {
+const COPY_VERIFY_HELP_CONTENT = `Copies the source(s) to the destination, then runs a read-only rclone check.
+
+Copy + Verify never deletes extra destination files. Verification reports missing, differing, and unreadable files so you can review them before repairing.
+
+Select the source(s) and destination, configure any options, and tap "START COPY + VERIFY". This workflow is manual-only; its progress and verification report are available from Transfers.`
+
+export type CopyMode = 'copy' | 'copy-verify'
+
+export default function Copy({ mode = 'copy' }: { mode?: CopyMode }) {
+    const isCopyVerify = mode === 'copy-verify'
     const [searchParams] = useSearchParams()
     const { globalFlags, filterFlags, configFlags, copyFlags } = useFlags()
 
@@ -93,7 +106,7 @@ export default function Copy() {
         [sources, dest]
     )
 
-    const buildArgs = () => ({
+    const buildArgs = (): CopyArgs => ({
         sources: sources!,
         destination: dest!,
         options: {
@@ -110,14 +123,15 @@ export default function Copy() {
                 throw new Error('Please select both a source and destination path')
             }
 
-            return startCopy(buildArgs())
+            const args = buildArgs()
+            return isCopyVerify ? startCopyVerify(args) : startCopy(args)
         },
         onSuccess: () => {
-            if (cronExpression) {
+            if (!isCopyVerify && cronExpression) {
                 scheduleTaskMutation.mutate()
             }
         },
-        onError: onErrorDialog('Copy', 'Failed to start copy', {
+        onError: onErrorDialog(isCopyVerify ? 'Copy + Verify' : 'Copy', 'Failed to start copy', {
             capture: false,
             log: ['Error starting copy:'],
         }),
@@ -165,9 +179,9 @@ export default function Copy() {
         if (!dest) return 'Please select a destination path'
         if (sources.some((s) => s === dest)) return 'Source and destination cannot be the same'
         if (jsonError) return 'Invalid JSON for ' + jsonError.toUpperCase() + ' options'
-        if (cronExpression) return 'START AND SCHEDULE COPY'
-        return 'START COPY'
-    }, [startCopyMutation.isPending, sources, dest, jsonError, cronExpression])
+        if (!isCopyVerify && cronExpression) return 'START AND SCHEDULE COPY'
+        return isCopyVerify ? 'START COPY + VERIFY' : 'START COPY'
+    }, [startCopyMutation.isPending, sources, dest, jsonError, cronExpression, isCopyVerify])
 
     const buttonIcon = useMemo(() => {
         if (startCopyMutation.isPending) return
@@ -209,7 +223,7 @@ export default function Copy() {
                     />
                 ),
             },
-            ...(schedulingAvailable
+            ...(!isCopyVerify && schedulingAvailable
                 ? [
                       {
                           key: 'cron',
@@ -275,10 +289,31 @@ export default function Copy() {
             selectedRemotes,
             cronExpression,
             schedulingAvailable,
+            isCopyVerify,
         ]
     )
 
-    const handleStart = useCallback(() => startCopyMutation.mutate(), [startCopyMutation.mutate])
+    const handleStart = useCallback(async () => {
+        if (
+            isCopyVerify &&
+            sources?.some((source) => {
+                const remoteName = getRemoteName(source)
+                return !remoteName || remoteName === ':local'
+            }) &&
+            dest &&
+            getRemoteName(dest) !== null &&
+            getRemoteName(dest) !== ':local'
+        ) {
+            const confirmed = await ask('This operation may replace differing destination files.', {
+                title: 'Copy + Verify',
+                kind: 'warning',
+                okLabel: 'Continue',
+                cancelLabel: 'Cancel',
+            })
+            if (!confirmed) return
+        }
+        startCopyMutation.mutate()
+    }, [dest, isCopyVerify, sources, startCopyMutation.mutate])
 
     const handleSchedule = useCallback(
         () => scheduleTaskMutation.mutate(),
@@ -345,8 +380,9 @@ export default function Copy() {
                     startIsPending={startCopyMutation.isPending}
                     onStart={handleStart}
                     onSchedule={handleSchedule}
-                    dryRunIsPending={dryRunMutation.isPending}
-                    onDryRun={handleDryRun}
+                    showSchedule={!isCopyVerify}
+                    dryRunIsPending={isCopyVerify ? undefined : dryRunMutation.isPending}
+                    onDryRun={isCopyVerify ? undefined : handleDryRun}
                     startBlocked={
                         !!jsonError ||
                         !sources ||
@@ -356,11 +392,11 @@ export default function Copy() {
                     }
                     buttonText={buttonText}
                     buttonIcon={buttonIcon}
-                    newLabel="NEW COPY"
+                    newLabel={isCopyVerify ? 'NEW COPY + VERIFY' : 'NEW COPY'}
                     onResetPaths={handleResetPaths}
                     onResetOptions={handleResetOptions}
                     onResetAll={handleResetAll}
-                    helpContent={HELP_CONTENT}
+                    helpContent={isCopyVerify ? COPY_VERIFY_HELP_CONTENT : HELP_CONTENT}
                 />
             </OperationWindowFooter>
         </div>

--- a/src/pages/Transfers.tsx
+++ b/src/pages/Transfers.tsx
@@ -6,10 +6,14 @@ import { ChevronRightIcon, RefreshCcwIcon, SearchCheckIcon } from 'lucide-react'
 import { startTransition, useCallback, useMemo, useState } from 'react'
 import { buildReadablePathMultiple, formatBytes } from '../../lib/format'
 import { listTransfers } from '../../lib/rclone/api'
+import { useHostStore } from '../../store/host'
 import { usePersistedStore } from '../../store/persisted'
+import { type CopyVerifyOperation, isCopyVerifyTerminal } from '../../types/copyVerify'
 import type { JobItem } from '../../types/jobs'
 import CommandsDropdown from '../components/CommandsDropdown'
 import JobDetailsDrawer from '../components/JobDetailsDrawer'
+import CopyVerifyCard from '../components/copyVerify/CopyVerifyCard'
+import CopyVerifyDetailsDrawer from '../components/copyVerify/CopyVerifyDetailsDrawer'
 
 export default function Transfers() {
     const { isOpen, onOpen, onClose } = useDisclosure({
@@ -34,7 +38,10 @@ export default function Transfers() {
         },
     })
     const [selectedJob, setSelectedJob] = useState<JobItem | null>(null)
+    const [selectedOperation, setSelectedOperation] = useState<CopyVerifyOperation | null>(null)
     const acknowledgements = usePersistedStore((state) => state.acknowledgements)
+    const copyVerifyOperations = useHostStore((state) => state.copyVerifyOperations)
+    const copyVerifyDisclosure = useDisclosure()
 
     const handleSelectJob = useCallback(
         (job: JobItem) => {
@@ -59,6 +66,31 @@ export default function Transfers() {
         [transfersQuery.data]
     )
 
+    const internalJobIds = useMemo(() => {
+        const ids = new Set<number>()
+        for (const operation of copyVerifyOperations) {
+            if (operation.copyJob) ids.add(operation.copyJob.jobId)
+            for (const job of [...operation.verificationJobs, ...operation.repairJobs])
+                ids.add(job.jobId)
+        }
+        return ids
+    }, [copyVerifyOperations])
+
+    const visibleTransfers = useMemo(
+        () => ({
+            active: transfers.active.filter((job) => !internalJobIds.has(job.id)),
+            inactive: transfers.inactive.filter((job) => !internalJobIds.has(job.id)),
+        }),
+        [internalJobIds, transfers]
+    )
+
+    const activeCopyVerify = copyVerifyOperations.filter(
+        (operation) => !isCopyVerifyTerminal(operation)
+    )
+    const inactiveCopyVerify = copyVerifyOperations.filter((operation) =>
+        isCopyVerifyTerminal(operation)
+    )
+
     if (transfersQuery.isLoading) {
         return (
             <div className="flex flex-col items-center justify-center h-screen">
@@ -67,7 +99,12 @@ export default function Transfers() {
         )
     }
 
-    if (!transfers || (transfers.active.length === 0 && transfers.inactive.length === 0)) {
+    if (
+        !transfers ||
+        (visibleTransfers.active.length === 0 &&
+            visibleTransfers.inactive.length === 0 &&
+            copyVerifyOperations.length === 0)
+    ) {
         return (
             <div className="flex flex-col items-center justify-center w-full h-screen gap-8">
                 <h1 className="text-2xl font-bold">No transfers found</h1>
@@ -92,12 +129,32 @@ export default function Transfers() {
                 variant="underlined"
             >
                 <Tab key="active" title="ACTIVE">
-                    {transfers.active.map((job) => (
+                    {activeCopyVerify.map((operation) => (
+                        <CopyVerifyCard
+                            key={operation.id}
+                            operation={operation}
+                            onSelect={(selected) => {
+                                setSelectedOperation(selected)
+                                copyVerifyDisclosure.onOpen()
+                            }}
+                        />
+                    ))}
+                    {visibleTransfers.active.map((job) => (
                         <JobCard key={job.id} job={job} onSelect={handleSelectJob} />
                     ))}
                 </Tab>
                 <Tab key="inactive" title="INACTIVE">
-                    {transfers.inactive.map((job) => (
+                    {inactiveCopyVerify.map((operation) => (
+                        <CopyVerifyCard
+                            key={operation.id}
+                            operation={operation}
+                            onSelect={(selected) => {
+                                setSelectedOperation(selected)
+                                copyVerifyDisclosure.onOpen()
+                            }}
+                        />
+                    ))}
+                    {visibleTransfers.inactive.map((job) => (
                         <JobCard key={job.id} job={job} onSelect={handleSelectJob} />
                     ))}
                 </Tab>
@@ -114,6 +171,20 @@ export default function Transfers() {
                     onClose={onClose}
                     selectedJob={selectedJob}
                     onSelectJob={handleSelectJob}
+                />
+            )}
+            {selectedOperation && (
+                <CopyVerifyDetailsDrawer
+                    operation={
+                        copyVerifyOperations.find(
+                            (operation) => operation.id === selectedOperation.id
+                        ) ?? selectedOperation
+                    }
+                    isOpen={copyVerifyDisclosure.isOpen}
+                    onClose={() => {
+                        copyVerifyDisclosure.onClose()
+                        setSelectedOperation(null)
+                    }}
                 />
             )}
         </>

--- a/store/host.ts
+++ b/store/host.ts
@@ -1,7 +1,9 @@
 import { LazyStore } from '@tauri-apps/plugin-store'
 import { create } from 'zustand'
 import { createJSONStorage, persist } from 'zustand/middleware'
+import { pruneTerminalOperations } from '../lib/copyVerify/history'
 import type { ConfigFile } from '../types/config'
+import type { CopyVerifyOperation, CopyVerifyUpdate } from '../types/copyVerify'
 import type { ScheduledTask } from '../types/schedules'
 import { createTauriStateStorage, waitForStoreHydration } from './lib'
 
@@ -68,7 +70,7 @@ export interface RemoteConfig {
     }
 }
 
-interface HostState {
+export interface HostState {
     remoteConfigs: Record<string, RemoteConfig>
     setRemoteConfig: (remote: string, config: RemoteConfig) => void
     mergeRemoteConfig: (remote: string, config: RemoteConfig) => void
@@ -116,6 +118,11 @@ interface HostState {
     // Atomically set both the intent and the ownership marker (a single store write, so a crash can
     // never land between them and desync intent from what we actually linked).
     setConfigSyncState: (state: { intent: boolean; linkTarget: string | null }) => void
+
+    copyVerifyOperations: CopyVerifyOperation[]
+    addCopyVerifyOperation: (operation: CopyVerifyOperation) => void
+    updateCopyVerifyOperation: (id: string, update: CopyVerifyUpdate) => void
+    pruneCopyVerifyOperations: (now?: number) => void
 }
 
 export const useHostStore = create<HostState>()(
@@ -188,12 +195,39 @@ export const useHostStore = create<HostState>()(
             syncConfigLinkTarget: null,
             setConfigSyncState: ({ intent, linkTarget }) =>
                 set((_) => ({ syncConfigToSystem: intent, syncConfigLinkTarget: linkTarget })),
+
+            copyVerifyOperations: [],
+            addCopyVerifyOperation: (operation) =>
+                set((state) => ({
+                    copyVerifyOperations: state.copyVerifyOperations.some(
+                        (existing) => existing.id === operation.id
+                    )
+                        ? state.copyVerifyOperations
+                        : [...state.copyVerifyOperations, operation],
+                })),
+            updateCopyVerifyOperation: (id, update) =>
+                set((state) => ({
+                    copyVerifyOperations: state.copyVerifyOperations.map((operation) =>
+                        operation.id === id
+                            ? {
+                                  ...operation,
+                                  ...update,
+                                  id: operation.id,
+                                  updatedAt: new Date().toISOString(),
+                              }
+                            : operation
+                    ),
+                })),
+            pruneCopyVerifyOperations: (now = Date.now()) =>
+                set((state) => ({
+                    copyVerifyOperations: pruneTerminalOperations(state.copyVerifyOperations, now),
+                })),
         }),
         {
             name: 'host-store',
             storage: createJSONStorage(() => createTauriStateStorage(() => activeStore)),
             skipHydration: true,
-            version: 2,
+            version: 3,
             migrate: (persistedState, version) => {
                 if (!persistedState) {
                     return persistedState
@@ -232,6 +266,15 @@ export const useHostStore = create<HostState>()(
                                 binaryPath: 'app-default',
                             })
                         ),
+                    }
+                }
+
+                if (version < 3) {
+                    state = {
+                        ...state,
+                        copyVerifyOperations: Array.isArray(state.copyVerifyOperations)
+                            ? state.copyVerifyOperations
+                            : [],
                     }
                 }
 

--- a/toolbar/actions.ts
+++ b/toolbar/actions.ts
@@ -85,6 +85,60 @@ const actions: ToolbarActionDefinition[] = [
         },
     },
     {
+        id: 'copy-verify',
+        label: 'Copy + Verify',
+        description: COMMAND_DESCRIPTIONS['copy-verify'],
+        keywords: COMMAND_KEYWORDS['copy-verify'],
+        getDefaultResult: () =>
+            createBaseResult('Copy + Verify', COMMAND_DESCRIPTIONS['copy-verify'], {}, 49),
+        getResults: ({ query, paths }) => {
+            if (query && !matchesKeyword(query, COMMAND_KEYWORDS['copy-verify'])) return []
+
+            if (paths.length === 0) {
+                return [
+                    createBaseResult('Copy + Verify', COMMAND_DESCRIPTIONS['copy-verify'], {}, 49),
+                ]
+            }
+
+            const results: ToolbarActionResult[] = []
+            if (paths.length === 2) {
+                const [source, destination] = paths
+                results.push(
+                    createBaseResult(
+                        `Copy + Verify ${source.readable} → ${destination.readable}`,
+                        COMMAND_DESCRIPTIONS['copy-verify'],
+                        {
+                            initialSource: normalizePathForArgs(source),
+                            initialDestination: normalizePathForArgs(destination),
+                        },
+                        199
+                    )
+                )
+            }
+
+            for (let index = 0; index < paths.length; index += 1) {
+                const path = paths[index]
+                const isDestination = paths.length > 1 && index === paths.length - 1
+                const args: ToolbarActionArgs = isDestination
+                    ? { initialDestination: normalizePathForArgs(path) }
+                    : { initialSource: normalizePathForArgs(path) }
+                results.push(
+                    createBaseResult(
+                        `Copy + Verify ${path.readable}`,
+                        COMMAND_DESCRIPTIONS['copy-verify'],
+                        args,
+                        isDestination ? 154 : 159
+                    )
+                )
+            }
+
+            return results
+        },
+        onPress: async (args, context) => {
+            await openCommandWindow('copy-verify', args, context)
+        },
+    },
+    {
         id: 'move',
         label: 'Move',
         description: COMMAND_DESCRIPTIONS.move,
@@ -1322,6 +1376,7 @@ function buildCommandParams(id: ConfiguredCommandId, args: ToolbarActionArgs): U
 
     switch (id) {
         case 'copy':
+        case 'copy-verify':
         case 'move':
         case 'sync':
         case 'bisync':

--- a/toolbar/constants.ts
+++ b/toolbar/constants.ts
@@ -31,7 +31,7 @@ const COMMANDER_DESCRIPTION = 'Open the Commander screen.'
 
 export const COMMAND_CONFIG = {
     copy: { route: '/copy', windowLabel: 'Copy' },
-    'copy-verify': { route: '/copy-verify', windowLabel: 'Copy + Verify' },
+    'copy-verify': { route: '/copy-verify', windowLabel: 'Copy-Verify' },
     move: { route: '/move', windowLabel: 'Move' },
     sync: { route: '/sync', windowLabel: 'Sync' },
     mount: { route: '/mount', windowLabel: 'Mount' },

--- a/toolbar/constants.ts
+++ b/toolbar/constants.ts
@@ -2,6 +2,8 @@ import type { ToolbarCommandId } from './types'
 
 const COPY_DESCRIPTION =
     'Copy files from a source to a destination without deleting destination files.'
+const COPY_VERIFY_DESCRIPTION =
+    'Copy files and verify the destination with a read-only rclone check.'
 const MOVE_DESCRIPTION =
     'Move files from a source to a destination and delete them from the source.'
 const SYNC_DESCRIPTION =
@@ -29,6 +31,7 @@ const COMMANDER_DESCRIPTION = 'Open the Commander screen.'
 
 export const COMMAND_CONFIG = {
     copy: { route: '/copy', windowLabel: 'Copy' },
+    'copy-verify': { route: '/copy-verify', windowLabel: 'Copy + Verify' },
     move: { route: '/move', windowLabel: 'Move' },
     sync: { route: '/sync', windowLabel: 'Sync' },
     mount: { route: '/mount', windowLabel: 'Mount' },
@@ -55,6 +58,7 @@ export const COMMAND_CONFIG = {
 
 export const COMMAND_DESCRIPTIONS: Record<ToolbarCommandId, string> = {
     copy: COPY_DESCRIPTION,
+    'copy-verify': COPY_VERIFY_DESCRIPTION,
     move: MOVE_DESCRIPTION,
     sync: SYNC_DESCRIPTION,
     mount: MOUNT_DESCRIPTION,
@@ -81,6 +85,7 @@ export const COMMAND_DESCRIPTIONS: Record<ToolbarCommandId, string> = {
 
 export const COMMAND_KEYWORDS: Record<ToolbarCommandId, string[]> = {
     copy: ['copy', 'cp', 'transfer'],
+    'copy-verify': ['copy', 'verify', 'checksum', 'transfer'],
     move: ['move', 'mv'],
     sync: ['sync', 'synchronise', 'synchronize'],
     mount: ['mount'],

--- a/toolbar/types.ts
+++ b/toolbar/types.ts
@@ -2,6 +2,7 @@ import type { RcloneFeatures } from '../types/rclone'
 
 export type ToolbarCommandId =
     | 'copy'
+    | 'copy-verify'
     | 'move'
     | 'sync'
     | 'mount'

--- a/types/copyVerify.ts
+++ b/types/copyVerify.ts
@@ -1,0 +1,90 @@
+import type { BatchInput, CopyArgs } from '../lib/rclone/requests'
+
+export type VerificationMethod =
+    | { kind: 'checksum'; hashTypes: string[] }
+    | { kind: 'size_only'; hashTypes: [] }
+    | { kind: 'mixed'; hashTypes: string[] }
+    | { kind: 'unknown'; hashTypes: string[] }
+
+export interface TransferUnit {
+    id: string
+    kind: 'file' | 'folder'
+    sourceDisplayPath: string
+    destinationDisplayPath: string
+    copyInput: BatchInput
+    verificationInput: BatchInput
+}
+
+export interface CopyVerifyPlan {
+    units: TransferUnit[]
+    copyInputs: BatchInput[]
+    verificationInputs: BatchInput[]
+}
+
+export type CopyVerifyPhase =
+    | 'submitting_copy'
+    | 'copying'
+    | 'submitting_verification'
+    | 'verifying'
+    | 'repairing'
+    | 'verification_required'
+    | 'complete'
+
+export type CopyVerifyResult =
+    | 'verified'
+    | 'verified_with_limitations'
+    | 'copy_failed'
+    | 'verification_failed'
+    | 'cancelled'
+    | null
+
+export interface RcloneJobRef {
+    jobId: number
+    executeId: string
+    group: string
+    attempt: number
+    startedAt: string
+    finishedAt?: string
+}
+
+export interface VerificationIssue {
+    unitId: string
+    path: string
+    message?: string
+}
+
+export interface CopyVerifyOperation {
+    id: string
+    hostId: string
+    sources: string[]
+    destination: string
+    createdAt: string
+    updatedAt: string
+    completedAt?: string
+
+    phase: CopyVerifyPhase
+    result: CopyVerifyResult
+    verificationMethod?: VerificationMethod
+    filesChecked: number | null
+
+    missingFiles: VerificationIssue[]
+    differentFiles: VerificationIssue[]
+    errors: VerificationIssue[]
+
+    copyDurationSeconds?: number
+    verificationDurationSeconds?: number
+    totalDurationSeconds?: number
+
+    copyJob?: RcloneJobRef
+    verificationJobs: RcloneJobRef[]
+    repairJobs: RcloneJobRef[]
+
+    transferUnits: TransferUnit[]
+    executionOptions: CopyArgs['options']
+}
+
+export type CopyVerifyUpdate = Partial<Omit<CopyVerifyOperation, 'id' | 'hostId' | 'createdAt'>>
+
+export function isCopyVerifyTerminal(operation: CopyVerifyOperation): boolean {
+    return operation.phase === 'complete' || operation.phase === 'verification_required'
+}


### PR DESCRIPTION
## What changed

Adds a manual-only Copy + Verify workflow to the Rclone UI fork.

- Reuses the existing Copy transfer planner and preserves Copy behavior.
- Adds strict asynchronous rclone copy/check aggregation with executeId validation.
- Adds persisted per-host operation history, recovery boundaries, repair, Verify Again, reports, and 90-day retention.
- Adds the `/copy-verify` route, command/toolbar entries, confirmation flow, and combined Transfers UI.
- Adds unit coverage and a temporary local-rclone integration harness.

## Validation

- `npm ci`
- `npm run test -- --silent` — 20 tests passed
- `npm run test:local-rclone` — passed
- `npm run build` — passed
- Targeted Biome checks for changed files — passed with existing warnings
- `cargo test --manifest-path src-tauri/Cargo.toml` — not run because Cargo is unavailable
- Full Biome check still reports six pre-existing diagnostics in navigator/settings/toolbar code
- Tauri UI smoke test is blocked by the missing Cargo toolchain; plain Vite cannot initialize Tauri plugins
